### PR TITLE
docs fix: quote ya pack commands to avoid shell errors

### DIFF
--- a/chmod.yazi/README.md
+++ b/chmod.yazi/README.md
@@ -7,7 +7,7 @@ https://github.com/yazi-rs/plugins/assets/17523360/7aa3abc2-d057-498c-8473-a6282
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#chmod
+ya pack -a 'yazi-rs/plugins#chmod'
 ```
 
 ## Usage

--- a/diff.yazi/README.md
+++ b/diff.yazi/README.md
@@ -7,7 +7,7 @@ https://github.com/yazi-rs/plugins/assets/17523360/eff5e949-386a-44ea-82f9-4cb4a
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#diff
+ya pack -a 'yazi-rs/plugins#diff'
 ```
 
 ## Usage

--- a/full-border.yazi/README.md
+++ b/full-border.yazi/README.md
@@ -7,7 +7,7 @@ Add a full border to Yazi to make it look fancier.
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#full-border
+ya pack -a 'yazi-rs/plugins#full-border'
 ```
 
 ## Usage

--- a/hide-preview.yazi/README.md
+++ b/hide-preview.yazi/README.md
@@ -7,7 +7,7 @@ https://github.com/yazi-rs/plugins/assets/17523360/c4f0b5c4-ff9f-4be8-ba73-4d8e7
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#hide-preview
+ya pack -a 'yazi-rs/plugins#hide-preview'
 ```
 
 ## Usage

--- a/jump-to-char.yazi/README.md
+++ b/jump-to-char.yazi/README.md
@@ -7,7 +7,7 @@ https://github.com/yazi-rs/plugins/assets/17523360/aac9341c-b416-4e0c-aaba-889d4
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#jump-to-char
+ya pack -a 'yazi-rs/plugins#jump-to-char'
 ```
 
 ## Usage

--- a/lsar.yazi/README.md
+++ b/lsar.yazi/README.md
@@ -10,7 +10,7 @@ but we strongly discourage using it unless you encounter some issues with `7zip`
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#lsar
+ya pack -a 'yazi-rs/plugins#lsar'
 ```
 
 ## Usage

--- a/max-preview.yazi/README.md
+++ b/max-preview.yazi/README.md
@@ -7,7 +7,7 @@ https://github.com/yazi-rs/plugins/assets/17523360/8976308e-ebfe-4e9e-babe-153eb
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#max-preview
+ya pack -a 'yazi-rs/plugins#max-preview'
 ```
 
 ## Usage

--- a/no-status.yazi/README.md
+++ b/no-status.yazi/README.md
@@ -7,7 +7,7 @@ Remove the status bar.
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#no-status
+ya pack -a 'yazi-rs/plugins#no-status'
 ```
 
 ## Usage

--- a/smart-filter.yazi/README.md
+++ b/smart-filter.yazi/README.md
@@ -7,7 +7,7 @@ https://github.com/yazi-rs/plugins/assets/17523360/72aaf117-1378-4f7e-93ba-d425a
 ## Installation
 
 ```sh
-ya pack -a yazi-rs/plugins#smart-filter
+ya pack -a 'yazi-rs/plugins#smart-filter'
 ```
 
 ## Usage


### PR DESCRIPTION
e.g. in zsh shell using `#` in commands without putting single quotes may be mistaken for glob pattern matching, like below:

```sh
ya pack -a yazi-rs/plugins#smart-filter
zsh: no matches found: yazi-rs/plugins#smart-filter
```

Thus quoting may ease the copy-paste experience while following install instructions.