### PR TITLE
refactor(full-border): remove `v4` function since Yazi v0.4 is released

### DIFF
--- a/full-border.yazi/init.lua
+++ b/full-border.yazi/init.lua
@@ -5,16 +5,13 @@ local function setup(_, opts)
 	Tab.build = function(self, ...)
 		local bar = function(c, x, y)
 			if x <= 0 or x == self._area.w - 1 then
-				return ui.Bar(ui.Bar.TOP):area(ui.Rect.default):style(style)
+				return ui.Bar(ui.Bar.TOP)
 			end
 
 			return ui.Bar(ui.Bar.TOP)
-				:area(ui.Rect {
-					x = x,
-					y = math.max(0, y),
-					w = ya.clamp(0, self._area.w - x, 1),
-					h = math.min(1, self._area.h),
-				})
+				:area(
+					ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) }
+				)
 				:symbol(c)
 		end
 
@@ -29,7 +26,7 @@ local function setup(_, opts)
 		self._base = ya.list_merge(self._base or {}, {
 			ui.Border(ui.Border.ALL):area(self._area):type(type):style(style),
 			ui.Bar(ui.Bar.RIGHT):area(self._chunks[1]):style(style),
-			ui.Bar(ui.Bar.LEFT):area(self._chunks[1]):style(style),
+			ui.Bar(ui.Bar.LEFT):area(self._chunks[3]):style(style),
 
 			bar("┬", c[1].right - 1, c[1].y),
 			bar("┴", c[1].right - 1, c[1].bottom - 1),

--- a/full-border.yazi/init.lua
+++ b/full-border.yazi/init.lua
@@ -1,12 +1,3 @@
--- TODO: remove this once v0.4 is released
-local v4 = function(typ, area, ...)
-	if typ == "bar" then
-		return ui.Table and ui.Bar(...):area(area) or ui.Bar(area, ...)
-	else
-		return ui.Table and ui.Border(...):area(area) or ui.Border(area, ...)
-	end
-end
-
 local function setup(_, opts)
 	local type = opts and opts.type or ui.Border.ROUNDED
 	local old_build = Tab.build
@@ -14,14 +5,17 @@ local function setup(_, opts)
 	Tab.build = function(self, ...)
 		local bar = function(c, x, y)
 			if x <= 0 or x == self._area.w - 1 then
-				return v4("bar", ui.Rect.default, ui.Bar.TOP)
+				return ui.Bar(ui.Bar.TOP):area(ui.Rect.default):style(style)
 			end
 
-			return v4(
-				"bar",
-				ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) },
-				ui.Bar.TOP
-			):symbol(c)
+			return ui.Bar(ui.Bar.TOP)
+				:area(ui.Rect {
+					x = x,
+					y = math.max(0, y),
+					w = ya.clamp(0, self._area.w - x, 1),
+					h = math.min(1, self._area.h),
+				})
+				:symbol(c)
 		end
 
 		local c = self._chunks
@@ -33,9 +27,9 @@ local function setup(_, opts)
 
 		local style = THEME.manager.border_style
 		self._base = ya.list_merge(self._base or {}, {
-			v4("border", self._area, ui.Border.ALL):type(type):style(style),
-			v4("bar", self._chunks[1], ui.Bar.RIGHT):style(style),
-			v4("bar", self._chunks[3], ui.Bar.LEFT):style(style),
+			ui.Border(ui.Border.ALL):area(self._area):type(type):style(style),
+			ui.Bar(ui.Bar.RIGHT):area(self._chunks[1]):style(style),
+			ui.Bar(ui.Bar.LEFT):area(self._chunks[1]):style(style),
 
 			bar("┬", c[1].right - 1, c[1].y),
 			bar("┴", c[1].right - 1, c[1].bottom - 1),


### PR DESCRIPTION
I was working on updating the snippet I have in the `starship.yazi` readme that's based on this plugin and saw the TODO here, figured I would do a quick PR. Let me know if it's not what you had in mind.