### PR TITLE
feat: add smartcase setting for jump-to-char

### DIFF
--- a/jump-to-char.yazi/init.lua
+++ b/jump-to-char.yazi/init.lua
@@ -6,9 +6,15 @@ local changed = ya.sync(function(st, new)
 	return b or not cx.active.finder
 end)
 
+local get_smart = ya.sync(function(st) return st.smart end)
+
 local escape = function(s) return s == "." and "\\." or s end
 
 return {
+	setup = function(st, smart)
+		st.smart = smart or false
+	end,
+
 	entry = function()
 		local cands = {}
 		for i = 1, #AVAILABLE_CHARS do
@@ -22,7 +28,8 @@ return {
 
 		local kw = escape(cands[idx].on)
 		if changed(kw) then
-			ya.manager_emit("find_do", { "^" .. kw })
+			local smart = get_smart()
+			ya.manager_emit("find_do", { "^" .. kw, smart = smart })
 		else
 			ya.manager_emit("find_arrow", {})
 		end


### PR DESCRIPTION
This was my first draft. Some other things I considered were nesting the setup argument inside a table to make things more readable (i.e. the setup call would be `require("jump-to-char"):setup({ smart = true })`), or supporting arbitrary additional arguments to the `"find_do"` emit. Let me know if either of those sound useful!

Closes #35.