### PR TITLE
fix(mount): partition regex for linux

### DIFF
--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -178,7 +178,7 @@ function M.obtain()
 		if ya.target_os() == "macos" then
 			main, sub = p.src:match("^(/dev/disk%d+)(.+)$")
 		else
-			main, sub = p.src:match("^(/dev/[a-z]+[a-z])(%d+)$")
+			main, sub = p.src:match("^(/dev/[a-zA-Z0-9]+)(p?%d*)$")
 		end
 		if sub then
 			if last ~= main then


### PR DESCRIPTION
Fix Linux partition regex to correctly match:

* NVMe disks (e.g. `/dev/nvme0n1`)
* Unpartitioned devices (e.g. `/dev/sda`)

closes #52 

p.s.: Feel free to improve it, as regex is definitely not my strong point.