### PR TITLE
feat(mount): get fstype for unmounted partitions

### DIFF
--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -30,6 +30,14 @@ local update_cursor = ya.sync(function(self, cursor)
 	ya.render()
 end)
 
+local function get_fstype(p)
+	local cmd = "lsblk -n -o fstype" .. " " .. p
+	local hnd = io.popen(cmd)
+	local out = hnd:read("*a"):gsub("\n", "")
+	hnd:close()
+	return out
+end
+
 local M = {
 	keys = {
 		{ on = "q", run = "quit" },
@@ -179,8 +187,14 @@ function M.obtain()
 			main, sub = p.src:match("^(/dev/disk%d+)(.+)$")
 		elseif p.src:find("/dev/nvme", 1, true) == 1 then -- /dev/nvme0n1p1
 			main, sub = p.src:match("^(/dev/nvme%d+n%d+)(p%d+)$")
+			if sub then
+				p.fstype = p.fstype or get_fstype(p.src)
+			end
 		elseif p.src:find("/dev/sd", 1, true) == 1 then -- /dev/sda1
 			main, sub = p.src:match("^(/dev/sd[a-z])(%d+)$")
+			if sub then
+				p.fstype = p.fstype or get_fstype(p.src)
+			end
 		end
 		if sub then
 			if last ~= main then


### PR DESCRIPTION
The `get_fstype()` function should be called for unmounted partitions only.

I'm not entirely sure if this is the intended implementation, but I think it could at least serve as a starting point to address https://github.com/yazi-rs/plugins/pull/53#issuecomment-2607405736