### PR TITLE
feat(git): add `renamed` support

### DIFF
--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -15,7 +15,14 @@ ya pkg add yazi-rs/plugins:git
 Add the following to your `~/.config/yazi/init.lua`:
 
 ```lua
-require("git"):setup()
+-- This is the default options,
+-- you could call `setup` without arguments if you don't want to change them.
+require("git"):setup({
+   -- The order in which the status icon is displayed
+  order = 1500,
+  -- Whether to include `renamed` files in the status (or treat them as `deleted` and `added`)
+  renamed = false,
+})
 ```
 
 And register it as fetchers in your `~/.config/yazi/yazi.toml`:

--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -18,6 +18,8 @@ Add the following to your `~/.config/yazi/init.lua`:
 require("git"):setup {
 	-- Order of status signs showing in the linemode
 	order = 1500,
+	-- Whether to include `renamed` files in the status (or treat them as `deleted` and `added`)
+	renamed = false,
 }
 ```
 

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -239,13 +239,13 @@ local function fetch(_, job)
 
 	-- stylua: ignore
 	local cmd = Command("git")
-		:args({ "--no-optional-locks", "-c", "core.quotePath=", "status", "--porcelain", "-unormal", "--ignored=matching" })
+		:arg({ "--no-optional-locks", "-c", "core.quotePath=", "status", "--porcelain", "-unormal", "--ignored=matching" })
 		:stdout(Command.PIPED)
 
 	if get_opts().renamed then
 		cmd = cmd:cwd(repo)
 	else
-		cmd = cmd:cwd(tostring(cwd)):args({ "--no-renames" }):args(paths)
+		cmd = cmd:cwd(tostring(cwd)):arg({ "--no-renames" }):arg(paths)
 	end
 
 	local output, err = cmd:output()

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -159,14 +159,22 @@ local remove = ya.sync(function(st, cwd)
 	st.repos[repo] = nil
 end)
 
+---@return Options
+local get_opts = ya.sync(function(st)
+	---@cast st State
+	return st.opts
+end)
+
 ---@param st State
 ---@param opts Options
 local function setup(st, opts)
-	st.dirs = {}
-	st.repos = {}
-
 	opts = opts or {}
 	opts.order = opts.order or 1500
+	opts.renamed = opts.renamed or false
+
+	st.opts = opts
+	st.dirs = {}
+	st.repos = {}
 
 	local t = th.git or {}
 	local styles = {
@@ -229,10 +237,16 @@ local function fetch(_, job)
 	end
 
 	-- stylua: ignore
-	local output, err = Command("git")
-		:cwd(repo)
+	local cmd = Command("git")
 		:arg({ "--no-optional-locks", "-c", "core.quotePath=", "status", "--porcelain", "-unormal", "--ignored=matching" })
-		:output()
+
+	if get_opts().renamed then
+		cmd = cmd:cwd(repo)
+	else
+		cmd = cmd:cwd(tostring(cwd)):arg({ "--no-renames" }):arg(paths)
+	end
+
+	local output, err = cmd:output()
 	if not output then
 		return true, Err("Cannot spawn `git` command, error: %s", err)
 	end

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -225,6 +225,10 @@ end
 ---@type UnstableFetcher
 local function fetch(_, job)
 	local cwd = job.files[1].url.base or job.files[1].url.parent
+	if not cwd then
+		return true
+	end
+
 	local repo = root(cwd)
 	if not repo then
 		remove(tostring(cwd))

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -9,10 +9,11 @@ local WINDOWS = ya.target_family() == "windows"
 local CODES = {
 	unknown = 100, -- status cannot/not yet determined
 	excluded = 99, -- ignored directory
-	ignored = 6, -- ignored file
-	untracked = 5,
-	modified = 4,
-	added = 3,
+	ignored = 7, -- ignored file
+	untracked = 6,
+	modified = 5,
+	added = 4,
+	renamed = 3,
 	deleted = 2,
 	updated = 1,
 	clean = 0,
@@ -23,6 +24,7 @@ local PATTERNS = {
 	{ "?$", CODES.untracked },
 	{ "[MT]", CODES.modified },
 	{ "[AC]", CODES.added },
+	{ "R", CODES.renamed },
 	{ "D", CODES.deleted },
 	{ "U", CODES.updated },
 	{ "[AD][AD]", CODES.updated },
@@ -35,7 +37,12 @@ local function match(line)
 	for _, p in ipairs(PATTERNS) do
 		local path, pattern, code = nil, p[1], p[2]
 		if signs:find(pattern) then
-			path = line:sub(4, 4) == '"' and line:sub(5, -2) or line:sub(4)
+			if code == CODES.renamed then
+				path = line:match("^.+-> (.+)$")
+				path = path:sub(1, 1) == '"' and path:sub(2, -2) or path
+			else
+				path = line:sub(4, 4) == '"' and line:sub(5, -2) or line:sub(4)
+			end
 			path = WINDOWS and path:gsub("/", "\\") or path
 		end
 		if not path then
@@ -168,6 +175,7 @@ local function setup(st, opts)
 		[CODES.untracked] = t.untracked or ui.Style():fg("magenta"),
 		[CODES.modified] = t.modified or ui.Style():fg("yellow"),
 		[CODES.added] = t.added or ui.Style():fg("green"),
+		[CODES.renamed] = t.renamed or ui.Style():fg("yellow"),
 		[CODES.deleted] = t.deleted or ui.Style():fg("red"),
 		[CODES.updated] = t.updated or ui.Style():fg("yellow"),
 		[CODES.clean] = t.clean or ui.Style(),
@@ -178,6 +186,7 @@ local function setup(st, opts)
 		[CODES.untracked] = t.untracked_sign or "? ",
 		[CODES.modified] = t.modified_sign or " ",
 		[CODES.added] = t.added_sign or " ",
+		[CODES.renamed] = t.renamed_sign or "",
 		[CODES.deleted] = t.deleted_sign or " ",
 		[CODES.updated] = t.updated_sign or " ",
 		[CODES.clean] = t.clean_sign or "",
@@ -221,9 +230,8 @@ local function fetch(_, job)
 
 	-- stylua: ignore
 	local output, err = Command("git")
-		:cwd(tostring(cwd))
-		:arg({ "--no-optional-locks", "-c", "core.quotePath=", "status", "--porcelain", "-unormal", "--no-renames", "--ignored=matching" })
-		:arg(paths)
+		:cwd(repo)
+		:arg({ "--no-optional-locks", "-c", "core.quotePath=", "status", "--porcelain", "-unormal", "--ignored=matching" })
 		:output()
 	if not output then
 		return true, Err("Cannot spawn `git` command, error: %s", err)

--- a/git.yazi/types.lua
+++ b/git.yazi/types.lua
@@ -1,4 +1,5 @@
 ---@class State
+---@field opts Options The options to use in `fetch()` context
 ---@field dirs table<string, string|CODES> Mapping between a directory and its corresponding repository
 ---@field repos table<string, Changes> Mapping between a repository and the status of each of its files
 


### PR DESCRIPTION
This is the initial implementation of `renamed` support. Note that I removed `:args(paths)` and made the `git status` command always run at the repository root. This causes `fetcher` to process the entire git status output every time it runs, which will obviously lead to performance issues.

However, it seems we have no other choice: When using `:args(paths)`, the command never outputs renamed files, and since renames can occur across folders, it must be executed at the root directory.

We might consider adding an option to let users decide whether to enable this feature, even at the cost of performance.