### PR TITLE
feat(mount): rewrite to support sshfs mounts

### DIFF
--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -1,6 +1,58 @@
 --- @since 25.2.26
 
-local toggle_ui = ya.sync(function(self)
+local M = {
+	keys = {
+		{ on = "q",       run = "quit", },
+
+		{ on = "k",       run = "up", },
+		{ on = "j",       run = "down", },
+		{ on = "l",       run = { "enter", "quit", }, },
+
+		{ on = "<Up>",    run = "up", },
+		{ on = "<Down>",  run = "down", },
+		{ on = "<Right>", run = { "enter", "quit", }, },
+
+		{ on = "m",       run = "mount", },
+		{ on = "u",       run = "unmount", },
+		{ on = "e",       run = "eject", },
+	},
+}
+
+---@type fun(): string
+local MUI_get_fstype = ya.sync(function(self)
+	---@cast self PluginState
+	return self.fstype or "*"
+end)
+
+---@type fun(fstype: string): nil
+local MUI_set_fstype = ya.sync(function(self, fstype)
+	---@cast self PluginState
+	self.fstype = fstype
+end)
+
+---@type fun(): nil
+local MUI_refresh = ya.sync(function(self)
+	---@cast self PluginState
+	ya.mgr_emit("plugin", { self._id, "__refresh", })
+end)
+
+---@type fun(): nil
+local MUI_subscribe_to_mounts = ya.sync(function()
+	ps.unsub("mount")
+	ps.sub("mount", function()
+		MUI_refresh()
+	end)
+end)
+
+---@type fun(): MountDescription
+local MUI_get_selected_entry = ya.sync(function(self)
+	---@cast self PluginState
+	return self.entries[self.cursor + 1]
+end)
+
+---@type fun(): nil
+local MUI_toggle = ya.sync(function(self)
+	---@cast self PluginState
 	if self.children then
 		Modal:children_remove(self.children)
 		self.children = nil
@@ -10,207 +62,54 @@ local toggle_ui = ya.sync(function(self)
 	ya.render()
 end)
 
-local subscribe = ya.sync(function(self)
-	ps.unsub("mount")
-	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "refresh" }) end)
-end)
-
-local update_partitions = ya.sync(function(self, partitions)
-	self.partitions = partitions
-	self.cursor = math.max(0, math.min(self.cursor or 0, #self.partitions - 1))
-	ya.render()
-end)
-
-local active_partition = ya.sync(function(self) return self.partitions[self.cursor + 1] end)
-
-local update_cursor = ya.sync(function(self, cursor)
-	if #self.partitions == 0 then
-		self.cursor = 0
+---@type fun(cursor: number): nil
+local MUI_update_cursor = ya.sync(function(self, cursor)
+	---@cast self PluginState
+	if #self.entries ~= 0 then
+		self.cursor = ya.clamp(0, self.cursor + cursor, #self.entries - 1)
 	else
-		self.cursor = ya.clamp(0, self.cursor + cursor, #self.partitions - 1)
+		self.cursor = 0
 	end
 	ya.render()
 end)
 
-local M = {
-	keys = {
-		{ on = "q", run = "quit" },
+---@type fun(entries: table<number, MountDescription>): nil
+local MUI_set_entry_cache = ya.sync(function(self, entries)
+	---@cast self PluginState
+	self.entries = entries
+	self.cursor = math.max(0, math.min(self.cursor or 0, #self.entries - 1))
+	ya.render()
+end)
 
-		{ on = "k", run = "up" },
-		{ on = "j", run = "down" },
-		{ on = "l", run = { "enter", "quit" } },
-
-		{ on = "<Up>", run = "up" },
-		{ on = "<Down>", run = "down" },
-		{ on = "<Right>", run = { "enter", "quit" } },
-
-		{ on = "m", run = "mount" },
-		{ on = "u", run = "unmount" },
-		{ on = "e", run = "eject" },
-	},
-}
-
-function M:new(area)
-	self:layout(area)
-	return self
+local function command_mock()
+	return { status = { success = true, }, }, ""
 end
 
-function M:layout(area)
-	local chunks = ui.Layout()
-		:constraints({
-			ui.Constraint.Percentage(10),
-			ui.Constraint.Percentage(80),
-			ui.Constraint.Percentage(10),
-		})
-		:split(area)
+---@return table<string, string>
+local function sshfs_get_mounted_hosts_map()
+	local mounts = {}
+	local output, err = Command("mount"):args({ "-t", "fuse.sshfs", }):output()
+	if err or not output.status.success then
+		M.fail("Failed to read system active mounts %s %s", err, output.stderr)
+	end
 
-	local chunks = ui.Layout()
-		:direction(ui.Layout.HORIZONTAL)
-		:constraints({
-			ui.Constraint.Percentage(10),
-			ui.Constraint.Percentage(80),
-			ui.Constraint.Percentage(10),
-		})
-		:split(chunks[2])
+	for value in output.stdout:gmatch("([^\r\n]+)") do
+		local host, location = value:match("(%S+) on (%S+)")
+		mounts[host] = location
+	end
 
-	self._area = chunks[2]
+	return mounts
 end
 
-function M:entry(job)
-	if job.args[1] == "refresh" then
-		return update_partitions(self.obtain())
-	end
-
-	toggle_ui()
-	update_partitions(self.obtain())
-	subscribe()
-
-	local tx1, rx1 = ya.chan("mpsc")
-	local tx2, rx2 = ya.chan("mpsc")
-	function producer()
-		while true do
-			local cand = self.keys[ya.which { cands = self.keys, silent = true }] or { run = {} }
-			for _, r in ipairs(type(cand.run) == "table" and cand.run or { cand.run }) do
-				tx1:send(r)
-				if r == "quit" then
-					toggle_ui()
-					return
-				end
-			end
-		end
-	end
-
-	function consumer1()
-		repeat
-			local run = rx1:recv()
-			if run == "quit" then
-				tx2:send(run)
-				break
-			elseif run == "up" then
-				update_cursor(-1)
-			elseif run == "down" then
-				update_cursor(1)
-			elseif run == "enter" then
-				local active = active_partition()
-				if active and active.dist then
-					ya.mgr_emit("cd", { active.dist })
-				end
-			else
-				tx2:send(run)
-			end
-		until not run
-	end
-
-	function consumer2()
-		repeat
-			local run = rx2:recv()
-			if run == "quit" then
-				break
-			elseif run == "mount" then
-				self.operate("mount")
-			elseif run == "unmount" then
-				self.operate("unmount")
-			elseif run == "eject" then
-				self.operate("eject")
-			end
-		until not run
-	end
-
-	ya.join(producer, consumer1, consumer2)
-end
-
-function M:reflow() return { self } end
-
-function M:redraw()
-	local rows = {}
-	for _, p in ipairs(self.partitions or {}) do
-		if not p.sub then
-			rows[#rows + 1] = ui.Row { p.main }
-		elseif p.sub == "" then
-			rows[#rows + 1] = ui.Row { p.main, p.label or "", p.dist or "", p.fstype or "" }
-		else
-			rows[#rows + 1] = ui.Row { "  " .. p.sub, p.label or "", p.dist or "", p.fstype or "" }
-		end
-	end
-
-	return {
-		ui.Clear(self._area),
-		ui.Border(ui.Border.ALL)
-			:area(self._area)
-			:type(ui.Border.ROUNDED)
-			:style(ui.Style():fg("blue"))
-			:title(ui.Line("Mount"):align(ui.Line.CENTER)),
-		ui.Table(rows)
-			:area(self._area:pad(ui.Pad(1, 2, 1, 2)))
-			:header(ui.Row({ "Src", "Label", "Dist", "FSType" }):style(ui.Style():bold()))
-			:row(self.cursor)
-			:row_style(ui.Style():fg("blue"):underline())
-			:widths {
-				ui.Constraint.Length(20),
-				ui.Constraint.Length(20),
-				ui.Constraint.Percentage(70),
-				ui.Constraint.Length(10),
-			},
+---@param src string
+local function blk_split_devices(src)
+	local paths = {
+		{ "^/dev/sd[a-z]",     "%d+$", }, -- /dev/sda1
+		{ "^/dev/nvme%d+n%d+", "p%d+$", }, -- /dev/nvme0n1p1
+		{ "^/dev/mmcblk%d+",   "p%d+$", }, -- /dev/mmcblk0p1
+		{ "^/dev/disk%d+",     ".+$", }, -- /dev/disk1s1
 	}
-end
-
-function M.obtain()
-	local tbl = {}
-	local last
-	for _, p in ipairs(fs.partitions()) do
-		local main, sub = M.split(p.src)
-		if main and last ~= main then
-			if p.src == main then
-				last, p.main, p.sub, tbl[#tbl + 1] = p.src, p.src, "", p
-			else
-				last, tbl[#tbl + 1] = main, { src = main, main = main, sub = "" }
-			end
-		end
-		if sub then
-			if tbl[#tbl].sub == "" and tbl[#tbl].main == main then
-				tbl[#tbl].sub = nil
-			end
-			p.main, p.sub, tbl[#tbl + 1] = main, sub, p
-		end
-	end
-	table.sort(M.fillin(tbl), function(a, b)
-		if a.main == b.main then
-			return (a.sub or "") < (b.sub or "")
-		else
-			return a.main > b.main
-		end
-	end)
-	return tbl
-end
-
-function M.split(src)
-	local pats = {
-		{ "^/dev/sd[a-z]", "%d+$" }, -- /dev/sda1
-		{ "^/dev/nvme%d+n%d+", "p%d+$" }, -- /dev/nvme0n1p1
-		{ "^/dev/mmcblk%d+", "p%d+$" }, -- /dev/mmcblk0p1
-		{ "^/dev/disk%d+", ".+$" }, -- /dev/disk1s1
-	}
-	for _, p in ipairs(pats) do
+	for _, p in ipairs(paths) do
 		local main = src:match(p[1])
 		if main then
 			return main, src:sub(#main + 1):match(p[2])
@@ -218,7 +117,8 @@ function M.split(src)
 	end
 end
 
-function M.fillin(tbl)
+---@param tbl table<number, MountDescription>
+local function lsblk_enrich_description(tbl)
 	if ya.target_os() ~= "linux" then
 		return tbl
 	end
@@ -233,7 +133,9 @@ function M.fillin(tbl)
 		return tbl
 	end
 
-	local output, err = Command("lsblk"):args({ "-p", "-o", "name,fstype", "-J" }):args(sources):output()
+	local output, err = Command("lsblk"):args({
+		"-p", "-o", "name,fstype", "-J",
+	}):args(sources):output()
 	if err then
 		ya.dbg("Failed to fetch filesystem types for unmounted partitions: " .. err)
 		return tbl
@@ -246,40 +148,279 @@ function M.fillin(tbl)
 	return tbl
 end
 
-function M.operate(type)
-	local active = active_partition()
-	if not active then
-		return
-	elseif not active.sub then
-		return -- TODO: mount/unmount main disk
-	end
+---@type table<string, FsProvider>
+local FS = {
+	["fuse.sshfs"] = {
+		refresh = true,
+		mount = function(desc)
+			Command("mkdir"):args({ "-p", desc.target, }):status()
+			return Command("sshfs"):args({
+				desc.src,
+				"-o", "reconnect,follow_symlinks",
+				desc.target,
+			}):output()
+		end,
 
-	local output, err
-	if ya.target_os() == "macos" then
-		output, err = Command("diskutil"):args({ type, active.src }):output()
-	end
-	if ya.target_os() == "linux" then
-		if type == "eject" then
-			Command("udisksctl"):args({ "unmount", "-b", active.src }):status()
-			output, err = Command("udisksctl"):args({ "power-off", "-b", active.src }):output()
-		else
-			output, err = Command("udisksctl"):args({ type, "-b", active.src }):output()
+		unmount = function(desc)
+			return Command("fusermount"):args({
+				"-u", desc.target,
+			}):output()
+		end,
+
+		get_possible_mounts = function()
+			local mounts = {}
+			local activeMounts = sshfs_get_mounted_hosts_map()
+			local file = io.open("/etc/hosts", "r")
+			if not file then
+				M.fail("Failed to read hosts file")
+				return {}
+			end
+
+			for line in file:lines() do
+				local ip, host = line:match("^(%S+)%s+(%S+)$")
+				if
+						ip and host and
+						not ip:match("^#") and
+						host ~= "localhost" and
+						ip ~= "0.0.0.0"
+				then
+					local sshhost = host .. ":"
+					mounts[#mounts + 1] = {
+						src = sshhost,
+						label = host,
+						dist = activeMounts[sshhost],
+						fstype = "fuse.sshfs",
+						target = string.format(
+							"%s/mount/ssh/%s",
+							os.getenv("HOME"),
+							host
+						),
+					}
+				end
+			end
+			file:close()
+
+			return mounts
+		end,
+
+		rows = function(entries)
+			local rows = {}
+			for i, v in ipairs(entries) do
+				rows[i] = ui.Row { v.src, v.label or "", v.dist or "", v.fstype or "", }
+			end
+			return rows
+		end,
+	},
+	["*"] = {
+		init = MUI_subscribe_to_mounts,
+
+		get_possible_mounts = function()
+			local tbl = {}
+			local last
+			for _, p in ipairs(fs.partitions()) do
+				local main, sub = blk_split_devices(p.src)
+				if main and last ~= main then
+					if p.src == main then
+						last, p.main, p.sub, tbl[#tbl + 1] = p.src, p.src, "", p
+					else
+						last, tbl[#tbl + 1] = main, { src = main, main = main, sub = "", }
+					end
+				end
+				if sub then
+					if tbl[#tbl].sub == "" and tbl[#tbl].main == main then
+						tbl[#tbl].sub = nil
+					end
+					p.main, p.sub, tbl[#tbl + 1] = main, sub, p
+				end
+			end
+			table.sort(lsblk_enrich_description(tbl), function(a, b)
+				if a.main == b.main then
+					return (a.sub or "") < (b.sub or "")
+				else
+					return a.main > b.main
+				end
+			end)
+			return tbl
+		end,
+
+		operate = function(desc, action)
+			if not desc.sub then return command_mock() end
+			if ya.target_os() == "macos" then
+				return Command("diskutil"):args({ action, desc.src, }):output()
+			end
+
+			return Command("udisksctl"):args({ action, "-b", desc.src, }):output()
+		end,
+
+		eject = function(desc)
+			if ya.target_os() ~= "linux" then return command_mock() end
+			Command("udisksctl"):args({ "unmount", "-b", desc.src, }):status()
+			return Command("udisksctl"):args({ "power-off", "-b", desc.src, }):output()
+		end,
+
+		rows = function(entries)
+			local rows = {}
+			for _, p in ipairs(entries) do
+				if not p.sub then
+					rows[#rows + 1] = ui.Row { p.main, }
+				elseif p.sub == "" then
+					rows[#rows + 1] = ui.Row { p.main, p.label or "", p.dist or "", p.fstype or "", }
+				else
+					rows[#rows + 1] = ui.Row { "  " .. p.sub, p.label or "", p.dist or "", p.fstype or "", }
+				end
+			end
+			return rows
+		end,
+	},
+}
+
+local MUI_resolve_fsimpl = function(fstype, force)
+	if fstype or force then MUI_set_fstype(fstype) end
+	fstype = MUI_get_fstype()
+
+	return FS[fstype]
+end
+
+function M:new(area)
+	self:layout(area)
+	return self
+end
+
+function M:redraw()
+	return {
+		ui.Clear(self._area),
+		ui.Border(ui.Border.ALL)
+				:area(self._area)
+				:type(ui.Border.ROUNDED)
+				:style(ui.Style():fg("blue"))
+				:title(ui.Line("Mount"):align(ui.Line.CENTER)),
+		ui.Table(MUI_resolve_fsimpl().rows(self.entries))
+				:area(self._area:pad(ui.Pad(1, 2, 1, 2)))
+				:header(ui.Row({ "Src", "Label", "Dist", "FSType", }):style(ui.Style():bold()))
+				:row(self.cursor)
+				:row_style(ui.Style():fg("blue"):underline())
+				:widths {
+					ui.Constraint.Length(20),
+					ui.Constraint.Length(20),
+					ui.Constraint.Percentage(70),
+					ui.Constraint.Length(10),
+				},
+	}
+end
+
+function M:layout(area)
+	local chunks = ui.Layout()
+			:constraints({
+				ui.Constraint.Percentage(10),
+				ui.Constraint.Percentage(80),
+				ui.Constraint.Percentage(10),
+			})
+			:split(area)
+
+	local chunks = ui.Layout()
+			:direction(ui.Layout.HORIZONTAL)
+			:constraints({
+				ui.Constraint.Percentage(10),
+				ui.Constraint.Percentage(80),
+				ui.Constraint.Percentage(10),
+			})
+			:split(chunks[2])
+
+	self._area = chunks[2]
+end
+
+function M:loop()
+	local tx1, rx1 = ya.chan("mpsc")
+	local tx2, rx2 = ya.chan("mpsc")
+
+	local function producer()
+		while true do
+			local cand = self.keys[ya.which { cands = self.keys, silent = true, }] or { run = {}, }
+			for _, r in ipairs(type(cand.run) == "table" and cand.run or { cand.run, }) do
+				tx1:send(r)
+				if r == "quit" then
+					MUI_toggle()
+					return
+				end
+			end
 		end
 	end
 
-	if not output then
-		M.fail("Failed to %s `%s`: %s", type, active.src, err)
-	elseif not output.status.success then
-		M.fail("Failed to %s `%s`: %s", type, active.src, output.stderr)
+	local function consumer1()
+		repeat
+			local run = rx1:recv()
+			if run == "up" then
+				MUI_update_cursor(-1)
+			elseif run == "down" then
+				MUI_update_cursor(1)
+			elseif run == "enter" then
+				local active = MUI_get_selected_entry()
+				if active and active.dist then
+					ya.mgr_emit("cd", { active.dist, })
+				end
+			else
+				tx2:send(run)
+			end
+		until not run or run == "quit"
 	end
+
+	local function consumer2()
+		repeat
+			local run = rx2:recv()
+			if run == "quit" then return end
+
+			self.operate(MUI_get_selected_entry(), run)
+		until not run
+	end
+
+	ya.join(producer, consumer1, consumer2)
 end
 
-function M.fail(s, ...) ya.notify { title = "Mount", content = string.format(s, ...), timeout = 10, level = "error" } end
+function M.operate(active, action)
+	local impl = MUI_resolve_fsimpl()
+	local cb = impl[action] or impl["operate"]
+	if not cb then
+		M.fail("Action %s unsupported by %s provider", action, MUI_get_fstype())
+		return
+	end
+
+	local output, err = cb(active, action)
+	if not output then
+		M.fail("Failed to %s `%s`: %s", action, active.src, err)
+	elseif not output.status.success then
+		M.fail("Failed to %s `%s`: %s", action, active.src, output.stderr)
+	end
+
+	if impl.refresh == true then MUI_refresh() end
+end
+
+function M:reflow() return { self, } end
 
 function M:click() end
 
 function M:scroll() end
 
 function M:touch() end
+
+function M:entry(job)
+	local cmd = job.args[1]
+	if cmd == "__refresh" then
+		return MUI_set_entry_cache(
+			MUI_resolve_fsimpl().get_possible_mounts()
+		)
+	end
+	local fsimpl = MUI_resolve_fsimpl(cmd, true)
+
+	MUI_toggle()
+	MUI_set_entry_cache(
+		fsimpl.get_possible_mounts()
+	)
+
+	if fsimpl.init then fsimpl.init() end
+
+	M:loop()
+end
+
+function M.fail(s, ...) ya.notify { title = "Mount", content = string.format(s, ...), timeout = 10, level = "error", } end
 
 return M

--- a/mount.yazi/types.lua
+++ b/mount.yazi/types.lua
@@ -1,0 +1,34 @@
+---@class MountDescription
+---@field label string
+---@field src string source device?
+---@field target string | nil mount target
+---@field main string | nil main device
+---@field sub string | nil sub device
+---@field dist string | nil established mount point
+---@field fstype string | nil for memes
+
+---@alias DiskAction
+---|"eject"
+---|"mount"
+---|"unmount"
+
+---@alias FsTypes
+---|"*"
+---|"fuse.sshfs"
+
+---@class FsProvider
+---@field get_possible_mounts fun(): table<number, MountDescription> return list of possible mounts ready to be cached
+---@field rows fun(entries: MountDescription): table<any> return ui.Rows representation of devices
+---@field init nil | fun(): nil -- Perform any additional initialization
+---@field mount nil | fun(desc: MountDescription): any, string -- Command output and error if any
+---@field unmount  nil |fun(desc: MountDescription): any, string -- Command output and error if any
+---@field eject nil | fun(desc: MountDescription): any, string -- Command output and error if any
+---@field operate nil | fun(desc: MountDescription, action: DiskAction): any, string -- Command output and error if any
+---@field refresh nil | boolean Refresh after running action
+
+---@class PluginState
+---@field _id string plugin id
+---@field entries table<number, MountDescription> | nil cached filesystem provider entries
+---@field fstype FsTypes requested filesystem provider
+---@field cursor number cursor position in the view
+---@field children number probably id or returned modal actually dont care


### PR DESCRIPTION
SO i didn't want to write another plugin cause wanted shared view implementation and just occasionaly rewrote whole thing. Sorry...

Now two separate shortcuts are possible for different mount providers. And it's comparatively easy to add more even if i struggle to remember anything else beside this what might need separate commands.
```toml
# keymap.toml
prepend_keymaps = [
	{ on = [ "m" ], run = "plugin mount" },
	{ on = [ "s" ], run = "plugin mount fuse.sshfs" }
]
```

Old implementation is generally untouched.

The hosts coming from /etc/hosts yes i didn't bother to support windows nor actually parse ~/.ssh/config cause wildcards are evil we need actual domains!

Mounts goes to ~/mounts/ssh/$Src.

![image](https://github.com/user-attachments/assets/a0094465-798b-47bd-bf86-fb49464c88d0)


Isolation is kinda lacking tho probably need to be rewritten again. I miss require so much.

### The logic is following now

**entry** -> **resolve final provider** by first argument saving it to state(nil means "*" default implementation with udiscsksctl etc...) -> *cache* entries from(FsPlugin.get_possible_mounts) -> **show ui**(FsPlugin.rows(here goes cache))(kinda lazyish) -> register **system callbacks** if any(FsPlugin.init) -> **event loop**

on **action** -> **find** action in **FsPlugin table** or **fallback to "operate"** property if exists -> **call** action, **process** errors etc... -> **if FsPlugin.refresh call MUI_refresh** afterwards.

Quite a lot to review. And to circumvent question no i probably cant split this into smaller pr's.