### PR TITLE
chore(mount): add core type definitions

### DIFF
--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -35,10 +35,10 @@ end)
 ---@type fun(cursor: number): nil
 local MUI_update_cursor = ya.sync(function(self, cursor)
 	---@cast self PluginState
-	if #self.entries ~= 0 then
-		self.cursor = ya.clamp(0, self.cursor + cursor, #self.entries - 1)
-	else
+	if #self.entries == 0 then
 		self.cursor = 0
+	else
+		self.cursor = ya.clamp(0, self.cursor + cursor, #self.entries - 1)
 	end
 	ya.render()
 end)

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -1,7 +1,7 @@
 --- @since 25.2.26
 
 ---@type fun(): nil
-local MUI_toggle = ya.sync(function(self)
+local toggle_ui = ya.sync(function(self)
 	if self.children then
 		Modal:children_remove(self.children)
 		self.children = nil
@@ -12,14 +12,14 @@ local MUI_toggle = ya.sync(function(self)
 end)
 
 ---@type fun(): nil
-local MUI_subscribe_to_mounts = ya.sync(function(self)
+local subscribe = ya.sync(function(self)
 	---@cast self PluginState
 	ps.unsub("mount")
 	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "__refresh", }) end)
 end)
 
 ---@type fun(entries: table<number, MountDescription>): nil
-local MUI_set_entries_cache = ya.sync(function(self, entries)
+local update_partitions = ya.sync(function(self, entries)
 	---@cast self PluginState
 	self.entries = entries
 	self.cursor = math.max(0, math.min(self.cursor or 0, #self.entries - 1))
@@ -27,13 +27,13 @@ local MUI_set_entries_cache = ya.sync(function(self, entries)
 end)
 
 ---@type fun(): MountDescription
-local MUI_get_selected_entry = ya.sync(function(self)
+local active_partition = ya.sync(function(self)
 	---@cast self PluginState
 	return self.entries[self.cursor + 1]
 end)
 
 ---@type fun(cursor: number): nil
-local MUI_update_cursor = ya.sync(function(self, cursor)
+local update_cursor = ya.sync(function(self, cursor)
 	---@cast self PluginState
 	if #self.entries == 0 then
 		self.cursor = 0
@@ -89,12 +89,12 @@ end
 
 function M:entry(job)
 	if job.args[1] == "__refresh" then
-		return MUI_set_entries_cache(self.obtain())
+		return update_partitions(self.obtain())
 	end
 
-	MUI_toggle()
-	MUI_set_entries_cache(self.obtain())
-	MUI_subscribe_to_mounts()
+	toggle_ui()
+	update_partitions(self.obtain())
+	subscribe()
 
 	local tx1, rx1 = ya.chan("mpsc")
 	local tx2, rx2 = ya.chan("mpsc")
@@ -104,7 +104,7 @@ function M:entry(job)
 			for _, r in ipairs(type(cand.run) == "table" and cand.run or { cand.run }) do
 				tx1:send(r)
 				if r == "quit" then
-					MUI_toggle()
+					toggle_ui()
 					return
 				end
 			end
@@ -118,11 +118,11 @@ function M:entry(job)
 				tx2:send(run)
 				break
 			elseif run == "up" then
-				MUI_update_cursor(-1)
+				update_cursor(-1)
 			elseif run == "down" then
-				MUI_update_cursor(1)
+				update_cursor(1)
 			elseif run == "enter" then
-				local active = MUI_get_selected_entry()
+				local active = active_partition()
 				if active and active.dist then
 					ya.mgr_emit("cd", { active.dist })
 				end
@@ -258,7 +258,7 @@ function M.fillin(tbl)
 end
 
 function M.operate(type)
-	local active = MUI_get_selected_entry()
+	local active = active_partition()
 	if not active then
 		return
 	elseif not active.sub then

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -75,7 +75,7 @@ function M:layout(area)
 		})
 		:split(area)
 
-	chunks = ui.Layout()
+	local chunks = ui.Layout()
 		:direction(ui.Layout.HORIZONTAL)
 		:constraints({
 			ui.Constraint.Percentage(10),
@@ -98,7 +98,7 @@ function M:entry(job)
 
 	local tx1, rx1 = ya.chan("mpsc")
 	local tx2, rx2 = ya.chan("mpsc")
-	local function producer()
+	function producer()
 		while true do
 			local cand = self.keys[ya.which { cands = self.keys, silent = true }] or { run = {} }
 			for _, r in ipairs(type(cand.run) == "table" and cand.run or { cand.run }) do
@@ -111,7 +111,7 @@ function M:entry(job)
 		end
 	end
 
-	local function consumer1()
+	function consumer1()
 		repeat
 			local run = rx1:recv()
 			if run == "quit" then
@@ -132,7 +132,7 @@ function M:entry(job)
 		until not run
 	end
 
-	local function consumer2()
+	function consumer2()
 		repeat
 			local run = rx2:recv()
 			if run == "quit" then

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -20,18 +20,18 @@ local MUI_subscribe_to_mounts = ya.sync(function(self)
 	end)
 end)
 
----@type fun(): MountDescription
-local MUI_get_selected_entry = ya.sync(function(self)
-	---@cast self PluginState
-	return self.entries[self.cursor + 1]
-end)
-
 ---@type fun(entries: table<number, MountDescription>): nil
 local MUI_set_entries_cache = ya.sync(function(self, entries)
 	---@cast self PluginState
 	self.entries = entries
 	self.cursor = math.max(0, math.min(self.cursor or 0, #self.entries - 1))
 	ya.render()
+end)
+
+---@type fun(): MountDescription
+local MUI_get_selected_entry = ya.sync(function(self)
+	---@cast self PluginState
+	return self.entries[self.cursor + 1]
 end)
 
 ---@type fun(cursor: number): nil

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -15,9 +15,7 @@ end)
 local MUI_subscribe_to_mounts = ya.sync(function(self)
 	---@cast self PluginState
 	ps.unsub("mount")
-	ps.sub("mount", function()
-		ya.mgr_emit("plugin", { self._id, "__refresh", })
-	end)
+	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "__refresh", }) end)
 end)
 
 ---@type fun(entries: table<number, MountDescription>): nil

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -1,12 +1,6 @@
 --- @since 25.2.26
 
 ---@type fun(): nil
-local MUI_refresh = ya.sync(function(self)
-	---@cast self PluginState
-	ya.mgr_emit("plugin", { self._id, "__refresh", })
-end)
-
----@type fun(): nil
 local MUI_toggle = ya.sync(function(self)
 	if self.children then
 		Modal:children_remove(self.children)
@@ -18,10 +12,11 @@ local MUI_toggle = ya.sync(function(self)
 end)
 
 ---@type fun(): nil
-local MUI_subscribe_to_mounts = ya.sync(function()
+local MUI_subscribe_to_mounts = ya.sync(function(self)
+	---@cast self PluginState
 	ps.unsub("mount")
 	ps.sub("mount", function()
-		MUI_refresh()
+		ya.mgr_emit("plugin", { self._id, "__refresh", })
 	end)
 end)
 

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -2,6 +2,7 @@
 
 ---@type fun(): nil
 local toggle_ui = ya.sync(function(self)
+	---@cast self PluginState
 	if self.children then
 		Modal:children_remove(self.children)
 		self.children = nil

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -82,7 +82,7 @@ function M:layout(area)
 		})
 		:split(area)
 
-	local chunks = ui.Layout()
+	chunks = ui.Layout()
 		:direction(ui.Layout.HORIZONTAL)
 		:constraints({
 			ui.Constraint.Percentage(10),
@@ -105,7 +105,7 @@ function M:entry(job)
 
 	local tx1, rx1 = ya.chan("mpsc")
 	local tx2, rx2 = ya.chan("mpsc")
-	function producer()
+	local function producer()
 		while true do
 			local cand = self.keys[ya.which { cands = self.keys, silent = true }] or { run = {} }
 			for _, r in ipairs(type(cand.run) == "table" and cand.run or { cand.run }) do
@@ -118,7 +118,7 @@ function M:entry(job)
 		end
 	end
 
-	function consumer1()
+	local function consumer1()
 		repeat
 			local run = rx1:recv()
 			if run == "quit" then
@@ -139,7 +139,7 @@ function M:entry(job)
 		until not run
 	end
 
-	function consumer2()
+	local function consumer2()
 		repeat
 			local run = rx2:recv()
 			if run == "quit" then

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -15,7 +15,7 @@ end)
 local subscribe = ya.sync(function(self)
 	---@cast self PluginState
 	ps.unsub("mount")
-	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "refresh", }) end)
+	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "refresh" }) end)
 end)
 
 ---@type fun(entries: table<number, MountDescription>): nil

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -15,7 +15,7 @@ end)
 local subscribe = ya.sync(function(self)
 	---@cast self PluginState
 	ps.unsub("mount")
-	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "__refresh", }) end)
+	ps.sub("mount", function() ya.mgr_emit("plugin", { self._id, "refresh", }) end)
 end)
 
 ---@type fun(entries: table<number, MountDescription>): nil
@@ -88,7 +88,7 @@ function M:layout(area)
 end
 
 function M:entry(job)
-	if job.args[1] == "__refresh" then
+	if job.args[1] == "refresh" then
 		return update_partitions(self.obtain())
 	end
 

--- a/mount.yazi/types.lua
+++ b/mount.yazi/types.lua
@@ -1,0 +1,34 @@
+---@class MountDescription
+---@field label string
+---@field src string source device?
+---@field target string | nil mount target
+---@field main string | nil main device
+---@field sub string | nil sub device
+---@field dist string | nil established mount point
+---@field fstype string | nil for memes
+
+---@alias DiskAction
+---|"eject"
+---|"mount"
+---|"unmount"
+
+---@alias FsTypes
+---|"*"
+---|"fuse.sshfs"
+
+---@class FsProvider
+---@field get_possible_mounts fun(): table<number, MountDescription> return list of possible mounts ready to be cached
+---@field rows fun(entries: MountDescription): table<any> return ui.Rows representation of devices
+---@field init nil | fun(): nil -- Perform any additional initialization
+---@field mount nil | fun(desc: MountDescription): any, string -- Command output and error if any
+---@field unmount  nil |fun(desc: MountDescription): any, string -- Command output and error if any
+---@field eject nil | fun(desc: MountDescription): any, string -- Command output and error if any
+---@field operate nil | fun(desc: MountDescription, action: DiskAction): any, string -- Command output and error if any
+---@field refresh nil | boolean Refresh after running action
+
+---@class PluginState
+---@field _id string plugin id
+---@field entries table<number, MountDescription> | nil cached filesystem provider entries
+---@field fstype FsTypes requested filesystem provider
+---@field cursor number cursor position in the view
+---@field children number probably id or returned modal actually dont care

--- a/mount.yazi/types.lua
+++ b/mount.yazi/types.lua
@@ -21,7 +21,7 @@
 ---@field rows fun(entries: MountDescription): table<any> return ui.Rows representation of devices
 ---@field init nil | fun(): nil -- Perform any additional initialization
 ---@field mount nil | fun(desc: MountDescription): any, string -- Command output and error if any
----@field unmount  nil |fun(desc: MountDescription): any, string -- Command output and error if any
+---@field unmount nil |fun(desc: MountDescription): any, string -- Command output and error if any
 ---@field eject nil | fun(desc: MountDescription): any, string -- Command output and error if any
 ---@field operate nil | fun(desc: MountDescription, action: DiskAction): any, string -- Command output and error if any
 ---@field refresh nil | boolean Refresh after running action


### PR DESCRIPTION
Part 1 of #91 

Since code becomes fairly large after adding sshfs support and full typing i decided to go with some convention to remember api's which will be fully introduced later.

Rename self.partitions to self.entries cause UI becomes generalized.

refresh -> __refresh to make it more stand out as something internal cause later it shares first argument with fstype.