### PR TITLE
chore: add type hints for `git.yazi`

### DIFF
--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -1,15 +1,5 @@
 --- @since 25.5.31
 
----@alias Changes table<string, CODES>
-
----@class State
----@field dirs table<string, string|CODES> Mapping between a directory and its corresponding repository
----@field repos table<string, Changes> Mapping between a repository and the status of each of its files
-
----@class Options
----@field order number The order in which the status is displayed
----@field renamed boolean Whether to include renamed files in the status (or treat them as modified)
-
 local WINDOWS = ya.target_family() == "windows"
 
 -- The code of supported git status,

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -206,9 +206,9 @@ local function setup(st, opts)
 	end, opts.order)
 end
 
+---@type UnstableFetcher
 local function fetch(_, job)
-	local files = job.files ---@type File[]
-	local cwd = files[1].url.base
+	local cwd = job.files[1].url.base
 	local repo = root(cwd)
 	if not repo then
 		remove(tostring(cwd))
@@ -241,7 +241,7 @@ local function fetch(_, job)
 		end
 	end
 
-	if files[1].cha.is_dir then
+	if job.files[1].cha.is_dir then
 		ya.dict_merge(changed, bubble_up(changed))
 	end
 	ya.dict_merge(changed, propagate_down(excluded, cwd, Url(repo)))

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -216,7 +216,7 @@ local function fetch(_, job)
 	end
 
 	local paths = {}
-	for _, file in ipairs(files) do
+	for _, file in ipairs(job.files) do
 		paths[#paths + 1] = tostring(file.url)
 	end
 

--- a/git.yazi/type.lua
+++ b/git.yazi/type.lua
@@ -1,0 +1,9 @@
+---@class Options
+---@field order number The order in which the status is displayed
+---@field renamed boolean Whether to include renamed files in the status (or treat them as modified)
+
+---@alias Changes table<string, CODES>
+
+---@class State
+---@field dirs table<string, string|CODES> Mapping between a directory and its corresponding repository
+---@field repos table<string, Changes> Mapping between a repository and the status of each of its files

--- a/git.yazi/type.lua
+++ b/git.yazi/type.lua
@@ -1,9 +1,0 @@
----@class Options
----@field order number The order in which the status is displayed
----@field renamed boolean Whether to include renamed files in the status (or treat them as modified)
-
----@alias Changes table<string, CODES>
-
----@class State
----@field dirs table<string, string|CODES> Mapping between a directory and its corresponding repository
----@field repos table<string, Changes> Mapping between a repository and the status of each of its files

--- a/git.yazi/types.lua
+++ b/git.yazi/types.lua
@@ -1,0 +1,12 @@
+---@class State
+---@field dirs table<string, string|CODES> Mapping between a directory and its corresponding repository
+---@field repos table<string, Changes> Mapping between a repository and the status of each of its files
+
+---@class Options
+---@field order number The order in which the status is displayed
+---@field renamed boolean Whether to include renamed files in the status (or treat them as modified)
+
+-- TODO: move this to `types.yazi` once it's get stable
+---@alias UnstableFetcher fun(self: unknown, job: { files: File[] })
+
+---@alias Changes table<string, CODES>


### PR DESCRIPTION
This PR adds type hints to git.yazi, making development more convenient.

-----

I hope to continue making progress on #88 and the following PRs, and I'd appreciate it if you could also take a moment to review it.