### PR TITLE
feat(borders): Add option to not show borders, only padding

### DIFF
--- a/full-border.yazi/README.md
+++ b/full-border.yazi/README.md
@@ -24,6 +24,8 @@ Or you can customize the border type:
 require("full-border"):setup {
 	-- Available values: ui.Border.PLAIN, ui.Border.ROUNDED
 	type = ui.Border.ROUNDED,
+	-- Available values: false, true
+	borders = true,
 }
 ```
 

--- a/full-border.yazi/main.lua
+++ b/full-border.yazi/main.lua
@@ -6,18 +6,6 @@ local function setup(_, opts)
 	local no_borders = opts and opts.no_borders or false
 
 	Tab.build = function(self, ...)
-		local bar = function(c, x, y)
-			if x <= 0 or x == self._area.w - 1 or th.mgr.border_symbol ~= "│" then
-				return ui.Bar(ui.Bar.TOP)
-			end
-
-			return ui.Bar(ui.Bar.TOP)
-				:area(
-					ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) }
-				)
-				:symbol(c)
-		end
-
 		local c = self._chunks
 		self._chunks = {
 			c[1]:pad(ui.Pad.y(1)),
@@ -26,6 +14,18 @@ local function setup(_, opts)
 		}
 
 		if not no_borders then
+			local bar = function(c, x, y)
+				if x <= 0 or x == self._area.w - 1 or th.mgr.border_symbol ~= "│" then
+					return ui.Bar(ui.Bar.TOP)
+				end
+
+				return ui.Bar(ui.Bar.TOP)
+					:area(
+						ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) }
+					)
+					:symbol(c)
+			end
+
 			local style = th.mgr.border_style
 			self._base = ya.list_merge(self._base or {}, {
 				ui.Border(ui.Border.ALL):area(self._area):type(type):style(style),

--- a/full-border.yazi/main.lua
+++ b/full-border.yazi/main.lua
@@ -3,6 +3,7 @@
 local function setup(_, opts)
 	local type = opts and opts.type or ui.Border.ROUNDED
 	local old_build = Tab.build
+	local no_borders = opts and opts.no_borders or false
 
 	Tab.build = function(self, ...)
 		local bar = function(c, x, y)
@@ -12,7 +13,12 @@ local function setup(_, opts)
 
 			return ui.Bar(ui.Bar.TOP)
 				:area(
-					ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) }
+					ui.Rect({
+						x = x,
+						y = math.max(0, y),
+						w = ya.clamp(0, self._area.w - x, 1),
+						h = math.min(1, self._area.h),
+					})
 				)
 				:symbol(c)
 		end
@@ -24,17 +30,19 @@ local function setup(_, opts)
 			c[3]:pad(ui.Pad.y(1)),
 		}
 
-		local style = th.mgr.border_style
-		self._base = ya.list_merge(self._base or {}, {
-			ui.Border(ui.Border.ALL):area(self._area):type(type):style(style),
-			ui.Bar(ui.Bar.RIGHT):area(self._chunks[1]):style(style),
-			ui.Bar(ui.Bar.LEFT):area(self._chunks[3]):style(style),
+		if not no_borders then
+			local style = th.mgr.border_style
+			self._base = ya.list_merge(self._base or {}, {
+				ui.Border(ui.Border.ALL):area(self._area):type(type):style(style),
+				ui.Bar(ui.Bar.RIGHT):area(self._chunks[1]):style(style),
+				ui.Bar(ui.Bar.LEFT):area(self._chunks[3]):style(style),
 
-			bar("┬", c[1].right - 1, c[1].y),
-			bar("┴", c[1].right - 1, c[1].bottom - 1),
-			bar("┬", c[2].right, c[2].y),
-			bar("┴", c[2].right, c[2].bottom - 1),
-		})
+				bar("┬", c[1].right - 1, c[1].y),
+				bar("┴", c[1].right - 1, c[1].bottom - 1),
+				bar("┬", c[2].right, c[2].y),
+				bar("┴", c[2].right, c[2].bottom - 1),
+			})
+		end
 
 		old_build(self, ...)
 	end

--- a/full-border.yazi/main.lua
+++ b/full-border.yazi/main.lua
@@ -3,7 +3,10 @@
 local function setup(_, opts)
 	local type = opts and opts.type or ui.Border.ROUNDED
 	local old_build = Tab.build
-	local no_borders = opts and opts.no_borders or false
+	local borders = true
+	if opts and opts.borders ~= nil then
+		borders = opts.borders
+	end
 
 	Tab.build = function(self, ...)
 		local c = self._chunks
@@ -13,16 +16,19 @@ local function setup(_, opts)
 			c[3]:pad(ui.Pad.y(1)),
 		}
 
-		if not no_borders then
+		if borders then
 			local bar = function(c, x, y)
 				if x <= 0 or x == self._area.w - 1 or th.mgr.border_symbol ~= "│" then
 					return ui.Bar(ui.Bar.TOP)
 				end
 
 				return ui.Bar(ui.Bar.TOP)
-					:area(
-						ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) }
-					)
+					:area(ui.Rect {
+						x = x,
+						y = math.max(0, y),
+						w = ya.clamp(0, self._area.w - x, 1),
+						h = math.min(1, self._area.h),
+					})
 					:symbol(c)
 			end
 

--- a/full-border.yazi/main.lua
+++ b/full-border.yazi/main.lua
@@ -13,12 +13,7 @@ local function setup(_, opts)
 
 			return ui.Bar(ui.Bar.TOP)
 				:area(
-					ui.Rect({
-						x = x,
-						y = math.max(0, y),
-						w = ya.clamp(0, self._area.w - x, 1),
-						h = math.min(1, self._area.h),
-					})
+					ui.Rect { x = x, y = math.max(0, y), w = ya.clamp(0, self._area.w - x, 1), h = math.min(1, self._area.h) }
 				)
 				:symbol(c)
 		end


### PR DESCRIPTION
Add an option to choose whether or not to display borders.
Using a `no_borders` option in the `setup`

**Only without the plugin borders**
![image](https://github.com/user-attachments/assets/67a3ecd8-0963-4e98-8f58-166858f40f63)

**Without any border**
![image](https://github.com/user-attachments/assets/8d65b911-e854-41dd-9a01-78c1c2b3a535)