### PR TITLE
Fix a running microtask in smart-filter.yazi

### DIFF
--- a/smart-filter.yazi/main.lua
+++ b/smart-filter.yazi/main.lua
@@ -43,6 +43,7 @@ local function entry()
 		elseif event == 1 then
 			ya.emit("escape", { filter = true })
 			ya.emit(h.is_dir and "enter" or "open", { h.url })
+			break
 		end
 	end
 end


### PR DESCRIPTION
If I use smart-filter to edit a file (in Helix in my case) and then quit, I see a warning that "smart-filter.yazi micro task s running".

<img width="518" height="328" alt="image" src="https://github.com/user-attachments/assets/2dfed16c-b11a-445f-bed4-a06fc47bf508" />
