### PR TITLE
docs: replace `name` with `url`

### DIFF
--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -23,12 +23,12 @@ And register it as fetchers in your `~/.config/yazi/yazi.toml`:
 ```toml
 [[plugin.prepend_fetchers]]
 id   = "git"
-name = "*"
+url  = "*"
 run  = "git"
 
 [[plugin.prepend_fetchers]]
 id   = "git"
-name = "*/"
+url  = "*/"
 run  = "git"
 ```
 

--- a/mactag.yazi/README.md
+++ b/mactag.yazi/README.md
@@ -47,12 +47,12 @@ And register it as fetchers in your `~/.config/yazi/yazi.toml`:
 ```toml
 [[plugin.prepend_fetchers]]
 id   = "mactag"
-name = "*"
+url  = "*"
 run  = "mactag"
 
 [[plugin.prepend_fetchers]]
 id   = "mactag"
-name = "*/"
+url  = "*/"
 run  = "mactag"
 ```
 

--- a/mime-ext.yazi/README.md
+++ b/mime-ext.yazi/README.md
@@ -17,7 +17,7 @@ Add this to your `~/.config/yazi/yazi.toml`:
 ```toml
 [[plugin.prepend_fetchers]]
 id   = "mime"
-name = "*"
+url  = "*"
 run  = "mime-ext"
 prio = "high"
 ```


### PR DESCRIPTION
This was already done for `piper.yazi` in [`8f1d971`][0], but that missed the other plugins.

[0]: https://github.com/yazi-rs/plugins/commit/8f1d971