### PR TITLE
Fix warning msg on yazi >= 25.12.29

### DIFF
--- a/mime-ext.yazi/main.lua
+++ b/mime-ext.yazi/main.lua
@@ -1112,7 +1112,7 @@ function M.fallback_builtin(job, unknown, state)
 		indices[f:hash()] = i
 	end
 
-	local result = require("mime"):fetch(ya.dict_merge(job, { files = unknown }))
+	local result = require("mime.local"):fetch(ya.dict_merge(job, { files = unknown }))
 	for i, f in ipairs(unknown) do
 		if type(result) == "table" then
 			state[indices[f:hash()]] = result[i]


### PR DESCRIPTION
Fix warning message, while using mime-ext.yazi plugin, which use old mime fetcher