### PR TITLE
feat(mount): add new match patterns for device files

### DIFF
--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -171,7 +171,7 @@ function M:redraw()
 				ui.Constraint.Length(20),
 				ui.Constraint.Length(20),
 				ui.Constraint.Percentage(70),
-				ui.Constraint.Length(10),
+				ui.Constraint.Length(20),
 			},
 	}
 end

--- a/mount.yazi/main.lua
+++ b/mount.yazi/main.lua
@@ -212,6 +212,11 @@ function M.split(src)
 		{ "^/dev/mmcblk%d+", "p%d+$" }, -- /dev/mmcblk0p1
 		{ "^/dev/disk%d+", ".+$" }, -- /dev/disk1s1
 		{ "^/dev/sr%d+", ".+$" }, -- /dev/sr0
+		{ "^/dev/fd%d+", ".+$" }, -- /dev/fd0
+		{ "^/dev/md%d+", "p%d+$" }, -- /dev/md0p1
+		{ "^/dev/nbd%d+", "p%d+$" }, -- /dev/nbd0p1
+		{ "^/dev/bcache%d+", "p%d+$" }, -- /dev/bcache0p1
+		{ "^/dev/mapper/", ".+$" }, -- /dev/mapper/<name>
 	}
 	for _, p in ipairs(pats) do
 		local main = src:match(p[1])


### PR DESCRIPTION
## New Patterns

| Device Type | Pattern |
| --- | --- |
| Floppy Disk | `{ "^/dev/fd%d+", ".+$" }` |
| RAID Device | `{ "^/dev/md%d+", "p%d+$" }` |
| Network Block Device | `{ "^/dev/nbd%d+", "p%d+$" }` |
| Bcache Device | `{ "^/dev/bcache%d+", "p%d+$" }` |
| Device Mapper | `{ "^/dev/mapper/", ".+$" }` |

## References

- [Arch Wiki](https://wiki.archlinux.org/title/Device_file)
- [Wikipedia](https://en.wikipedia.org/wiki/Device_file#Naming_conventions)
- [The Linux Storage Stack Diagram (Linux Kernel 6.16)](https://www.thomas-krenn.com/de/wikiDE/images/f/f4/Linux-storage-stack-diagram_v6.16.pdf)