### PR TITLE
Comment: cache-based, scrolling-optimized version of piper.yazi

### DIFF
--- a/piper.yazi/README.md
+++ b/piper.yazi/README.md
@@ -93,6 +93,11 @@ url = "*"
 run = 'piper -- hexyl --border=none --terminal-width=$w "$1"'
 ```
 
+## Related projects
+
+[`faster-piper.yazi`](https://github.com/alberti42/faster-piper.yazi):
+a cache-based, scrolling-optimized rewrite compatible with `piper.yazi`.
+
 ## License
 
 This plugin is MIT-licensed. For more information check the [LICENSE](LICENSE) file.


### PR DESCRIPTION
Hi!

I wanted to put a related project on your radar without proposing a large or intrusive change to this repository.

Over the past weeks I’ve been working on a cache-based rewrite of `piper.yazi` called `faster-piper.yazi`: https://github.com/alberti42/faster-piper.yazi

It’s fully syntax-compatible with `piper.yazi`, but the internal design is significantly different (caching, file-backed paging, preload/peek coordination, and deterministic scrolling). The implementation ended up being ~700 LOC versus ~70 LOC here, which is why I published it as a **separate plugin** rather than opening a large PR against this repo.

This PR only adds a short note + link at the bottom of the README so that:
- users who need better performance for expensive preview commands can discover it,
- you (and others) become aware of the new development.

What do you think is the best way to proceed going forward: keep it as a separate “advanced” plugin, or consider upstreaming parts of the approach later (if that ever makes sense)?

For now, I’d appreciate merging this README-only pointer so interested users can find `faster-piper.yazi`.

Thanks again for `piper.yazi` — the “pipe any command into preview” idea is extremely useful, and it’s what motivated this work.