### PR TITLE
fix(git): ensure file/folder visual vertical alignment at right-end in linemode

### DIFF
--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -178,6 +178,15 @@ local function setup(st, opts)
 		[CODES.updated] = t.updated_sign or " ",
 	}
 
+	local width = 0
+	for _, sign in pairs(signs) do
+		local w = (ya.string_width and ya.string_width(sign)) or utf8.len(sign)
+		if w > width then
+			width = w
+		end
+	end
+	local placeholder = string.rep(" ", width)
+
 	Linemode:children_add(function(self)
 		if not self._file.in_current then
 			return ""
@@ -185,17 +194,26 @@ local function setup(st, opts)
 
 		local url = self._file.url
 		local repo = st.dirs[tostring(url.base or url.parent)]
-		local code
-		if repo then
-			code = repo == CODES.excluded and CODES.ignored or st.repos[repo][tostring(url):sub(#repo + 2)]
+		if not repo then
+			return ""
 		end
 
+		local code = repo == CODES.excluded and CODES.ignored or st.repos[repo][tostring(url):sub(#repo + 2)]
 		if not code or signs[code] == "" then
-			return ""
-		elseif self._file.is_hovered then
-			return ui.Line { " ", signs[code] }
+			return ui.Line { " ", placeholder }
+		end
+
+		local sign = signs[code]
+		local w = (ya.string_width and ya.string_width(sign)) or utf8.len(sign)
+		local padding = width - w
+		if padding > 0 then
+			sign = sign .. string.rep(" ", padding)
+		end
+
+		if self._file.is_hovered then
+			return ui.Line { " ", sign }
 		else
-			return ui.Line { " ", ui.Span(signs[code]):style(styles[code]) }
+			return ui.Line { " ", ui.Span(sign):style(styles[code]) }
 		end
 	end, opts.order)
 end


### PR DESCRIPTION
This PR tries to resolve visual issue where the git status column in Yazi's linemode would
cause rows to misalign. Previously, files without git status returned an empty string, and files with different icon widths (e.g., 1-character vs. 2-character icons) would cause the following columns to "jump" horizontally.

Changes:

-  Dynamic Width Detection: The plugin now iterates through all configured git status signs (including user-customized ones) during setup to determine the max_width.
-  Robust Width Calculation: Uses ya.string_width for accurate terminal cell measurement, falling back to utf8.len for compatibility with older Yazi versions and proper handling of multi-byte Nerd Font icons.
-  Strict Column Alignment: Files with no git status are now padded with exactly enough spaces to match the widest possible status icon.
-  Files with narrower icons are dynamically padded to match the max_width, ensuring the column width remains constant across all rows.
-  Structural Consistency: Standardized the rendering using ui.Line to ensure padding and prefix spaces are handled identically by the rendering engine.

Before:
<img width="956" height="147" alt="Screenshot 2026-01-21 at 20 55 58" src="https://github.com/user-attachments/assets/3258ad8f-03d5-474b-9f9c-72af7c1c28fb" />

After:
<img width="956" height="147" alt="Screenshot 2026-01-21 at 20 54 48" src="https://github.com/user-attachments/assets/be92f93a-484e-4a3c-8931-bc562fca86a5" />
