### PR TITLE
mount.yazi - new features and improvements

### DIFF
--- a/mount.yazi/README.md
+++ b/mount.yazi/README.md
@@ -34,8 +34,10 @@ You can customize the plugin by adding the following to your `~/.config/yazi/ini
 ```lua
 require("mount"):setup({
     -- Customizable keybindings (all optional, showing defaults)
+    -- Each action can have a single key or an array of keys
     keys = {
-        quit = "q",
+        quit = "q",           -- single key
+        -- quit = { "q", "n" },  -- multiple keys
         up = "k",
         down = "j",
         enter = "l",


### PR DESCRIPTION
This PR adds several new features and improvements to the mount plugin, and closes https://github.com/yazi-rs/plugins/issues/178 and https://github.com/yazi-rs/plugins/issues/132.

### New Features

- **Drive filtering**: Automatically hides the OS drive (containing root partition) to prevent accidental unmounting of system partitions. Works with LUKS encrypted setups.
  - `exclude_root_drive` (default: `true`) - Hide the entire drive containing `/`
  - `exclude_mounts` (default: `{"/", "/boot", "/boot/efi"}`) - Hide specific mount points
  - `exclude_fstypes` - Hide partitions by filesystem type
  - `exclude_devices` - Hide devices matching Lua patterns

- **Disk operations**: Mount, unmount, and eject entire disks (not just partitions)
  - Mount: Mounts all unmounted partitions on the disk
  - Unmount: Unmounts all mounted partitions on the disk
  - Eject: Unmounts all partitions and powers off the disk

- **Smart enter key**: Pressing enter/l/→ on a partition or disk will:
  - Mount if unmounted, then close the plugin
  - Unmount and eject if mounted, then close the plugin

- **Auto-navigate on unmount**: Navigate out of the symlink or mount point when unmounting to prevent errors

- **Custom keybinds**: Added ability to add one or more custom keybinds to each function

- **Keybinding hints bar**: Shows available keybindings at the bottom of the plugin window
  - Can be disabled with `show_help = false`
  - Automatically reflects custom keybindings

- **Optional symlink creation**: When enabled, symlinks to the mounted partitions are created in the $HOME directory, unless a custom path is configured

- **Symlink verification on removal**: When removing symlinks, verifies the symlink target matches the partition's mount point to avoid accidentally removing unrelated symlinks

### Improvements

- **Already mounted/unmounted warnings**: Friendly warning notifications instead of error messages when attempting to mount an already mounted partition/disk or unmount an already unmounted one
- **Added `<Left>` arrow as hardcoded quit key** (alongside `q` and `<Esc>`)
- **Fixed config persistence**: Keybindings and symlink settings now persist correctly across Yazi restarts

### Configuration

```lua
require("mount"):setup({
    -- Symlinks
    symlinks = false,
    symlink_dir = "$HOME",
    
    -- Filtering
    exclude_root_drive = true,
    exclude_mounts = { "/", "/boot", "/boot/efi" },
    exclude_fstypes = {},
    exclude_devices = {},
    
    -- UI
    show_help = true,
    
    -- Keybindings
    keys = {
        quit = { "q", "h" },
        up = "k",
        down = "j",
        enter = "l",
        mount = "m",
        unmount = "u",
        eject = "e",
    },
})
```