### PR TITLE
feat(jump-to-char): support ignorecase and smartcase

### DIFF
--- a/jump-to-char.yazi/README.md
+++ b/jump-to-char.yazi/README.md
@@ -21,6 +21,13 @@ run  = "plugin jump-to-char"
 desc = "Jump to char"
 ```
 
+By default, this is case sensitive. If you want it to be case insensitive, you
+can use `plugin jump-to-char -- --ignorecase`. Similarly, if you want smart
+case, i.e. typing a lowercase letter will result in both lowercase and
+uppercase characters to be matched, but not the other way around, then you can
+use `plugin jump-to-char -- --smartcase`.
+
+
 Note that, the keybindings above are just examples, please tune them up as needed to ensure they don't conflict with your other commands/plugins.
 
 ## License

--- a/jump-to-char.yazi/README.md
+++ b/jump-to-char.yazi/README.md
@@ -27,7 +27,6 @@ case, i.e. typing a lowercase letter will result in both lowercase and
 uppercase characters to be matched, but not the other way around, then you can
 use `plugin jump-to-char -- --smartcase`.
 
-
 Note that, the keybindings above are just examples, please tune them up as needed to ensure they don't conflict with your other commands/plugins.
 
 ## License

--- a/jump-to-char.yazi/main.lua
+++ b/jump-to-char.yazi/main.lua
@@ -11,7 +11,7 @@ end)
 local escape = function(s) return s == "." and "\\." or s end
 
 return {
-	entry = function()
+	entry = function(self, job)
 		local cands = {}
 		for i = 1, #AVAILABLE_CHARS do
 			cands[#cands + 1] = { on = AVAILABLE_CHARS:sub(i, i) }
@@ -21,10 +21,15 @@ return {
 		if not idx then
 			return
 		end
-
 		local kw = escape(cands[idx].on)
 		if changed(kw) then
-			ya.emit("find_do", { "^" .. kw })
+			if job.args.ignorecase and kw:match("%a") then
+				ya.emit("find_do", { "^(" .. kw:lower() .. "|" .. kw:upper() .. ")" })
+			elseif job.args.smartcase and kw:match("^%l$") then
+				ya.emit("find_do", { "^(" .. kw .. "|" .. kw:upper() .. ")" })
+			else
+				ya.emit("find_do", { "^" .. kw })
+			end
 		else
 			ya.emit("find_arrow", {})
 		end

--- a/jump-to-char.yazi/main.lua
+++ b/jump-to-char.yazi/main.lua
@@ -21,6 +21,7 @@ return {
 		if not idx then
 			return
 		end
+
 		local kw = escape(cands[idx].on)
 		if changed(kw) then
 			if job.args.ignorecase and kw:match("%a") then


### PR DESCRIPTION
Following my comment in https://github.com/yazi-rs/plugins/issues/112, I thought I might as well contribute the feature since it was discussed in https://github.com/yazi-rs/plugins/issues/35 as well.

In short, this adds two options which can be passed to the `jump-to-char` plugin: if none is passed, it defaults to being case-sensitive (like in vim); if `--ignorecase` is passed, then case is ignored, so any of `fa` and `fA` searches for `^(a|A)`; and if `--smartcase` is passed (and is not overriden by `--ignorecase`), only `fa` will search for this, and `fA` will search for `^A` like before.

- closes https://github.com/yazi-rs/plugins/issues/112
- closes https://github.com/yazi-rs/plugins/issues/35