### PR TITLE
feat: add git-nav-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For specific installation commands and configuration instructions, check the ind
 - [toggle-pane.yazi](toggle-pane.yazi) - Toggle the show, hide, and maximize states for different panes: parent, current, and preview.
 - [jump-to-char.yazi](jump-to-char.yazi) - Vim-like `f<char>`, jump to the next file whose name starts with `<char>`.
 - [git.yazi](git.yazi) - Show the status of Git file changes as linemode in the file list.
+- [git-nav.yazi](git-nav.yazi) - Navigate in a Git repo by jumping to the next/previous changed file/ go to git-root.
 - [mount.yazi](mount.yazi) - A mount manager for Yazi, providing disk mount, unmount, and eject functionality.
 - [vcs-files.yazi](vcs-files.yazi) - Show Git file changes in Yazi.
 - [piper.yazi](piper.yazi) - Pipe any shell command as a previewer.

--- a/git-nav.yazi/LICENSE
+++ b/git-nav.yazi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 yazi-rs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/git-nav.yazi/README.md
+++ b/git-nav.yazi/README.md
@@ -1,0 +1,46 @@
+# git-nav.yazi
+
+Helper plugin for Yazi to navigate through Git repo
+- go to git root `git-top`
+- go to git superproject root `git-super`
+- go to git directory `.git`
+- open lazygit `lazygit` (if installed)
+- go to next changed file `git-next`
+- go to previous changed file `git-prev`
+
+
+## Installation
+
+```sh
+ya pkg add yazi-rs/plugins:git-nav
+```
+
+## Setup
+
+prerequirements:
+- Yazi installed
+- Git installed
+- (optional) lazygit installed
+
+
+### Keymaps
+
+Add the following to your `~/.config/yazi/keymap.toml` to enable keymaps for git navigation:
+modify the file to your liking.
+
+```keymap.toml
+[mgr]
+prepend_keymap = [
+  { on = ["g", "t"], run = "plugin git-nav root",  desc = "Git root" },
+  { on = ["g", "s"], run = "plugin git-nav super", desc = "Git superproject root" },
+  { on = ["g", "g"], run = "plugin git-nav gitdir", desc = "Git directory" },
+  { on = ["g", "l"], run = "plugin git-nav lazygit", desc = "Open lazygit" },
+  { on = ["]", "g"], run = "plugin git-nav next", desc = "Next changed file" },
+  { on = ["[", "g"], run = "plugin git-nav prev", desc = "Previous changed file" },
+...
+]
+```
+
+## License
+
+This plugin is MIT-licensed. For more information check the [LICENSE](LICENSE) file.

--- a/git-nav.yazi/main.lua
+++ b/git-nav.yazi/main.lua
@@ -1,0 +1,146 @@
+--- @sync entry
+
+local function notify(msg)
+  ya.notify({
+    title = "Git",
+    content = msg,
+    timeout = 3,
+  })
+end
+
+local function git(cwd, args)
+  local tmpfile = os.tmpname()
+  local cmd = string.format("cd '%s' && git %s > '%s' 2>/dev/null", cwd, table.concat(args, " "), tmpfile)
+
+  os.execute(cmd)
+
+  local f = io.open(tmpfile, "r")
+  if not f then
+    os.remove(tmpfile)
+    return nil
+  end
+
+  local out = f:read("*a")
+  f:close()
+  os.remove(tmpfile)
+
+  out = out and out:gsub("%s+$", "") or ""
+
+  if out == "" then
+    return nil
+  end
+
+  return out
+end
+
+local function get_changed_files(root)
+  local out = git(root, { "status", "--porcelain" })
+  if not out then
+    return {}
+  end
+
+  local files = {}
+  for line in out:gmatch("[^\n]+") do
+    -- git status --porcelain format: XY filename
+    -- Skip first 3 chars (status + space)
+    local file = line:sub(4)
+    -- Handle renamed files (old -> new)
+    file = file:match("-> (.+)") or file
+    -- Remove quotes if present
+    file = file:gsub('^"', ''):gsub('"$', '')
+    if file ~= "" then
+      table.insert(files, root .. "/" .. file)
+    end
+  end
+
+  table.sort(files)
+  return files
+end
+
+local function navigate_changed(cwd, direction)
+  local root = git(cwd, { "rev-parse", "--show-toplevel" })
+  if not root then
+    notify("Not inside a git repository")
+    return
+  end
+
+  local files = get_changed_files(root)
+  if #files == 0 then
+    notify("No changed files")
+    return
+  end
+
+  -- Get current hovered file
+  local hovered = cx.active.current.hovered
+  local current_path = hovered and tostring(hovered.url.path) or cwd
+
+  -- Find current position in list
+  local current_idx = 0
+  for i, file in ipairs(files) do
+    if file == current_path or current_path:find(file, 1, true) then
+      current_idx = i
+      break
+    end
+  end
+
+  -- Calculate next index
+  local next_idx
+  if direction == "next" then
+    next_idx = current_idx + 1
+    if next_idx > #files then
+      next_idx = 1 -- wrap around
+    end
+  else -- prev
+    next_idx = current_idx - 1
+    if next_idx < 1 then
+      next_idx = #files -- wrap around
+    end
+  end
+
+  local target = files[next_idx]
+  ya.emit("reveal", { target })
+end
+
+local function entry(self, job)
+  local args = job.args or {}
+  local action = args[1]
+  local cwd = tostring(cx.active.current.cwd.path)
+
+  local path = nil
+
+  if action == "root" then
+    path = git(cwd, { "rev-parse", "--show-toplevel" })
+
+  elseif action == "super" then
+    path = git(cwd, { "rev-parse", "--show-superproject-working-tree" })
+        or git(cwd, { "rev-parse", "--show-toplevel" })
+
+  elseif action == "gitdir" then
+    path = git(cwd, { "rev-parse", "--git-common-dir" })
+
+  elseif action == "lazygit" then
+    if not git(cwd, { "rev-parse", "--is-inside-work-tree" }) then
+      notify("Not inside a git repository")
+      return
+    end
+    ya.emit("shell", { "lazygit", block = true })
+    return
+
+  elseif action == "next" then
+    navigate_changed(cwd, "next")
+    return
+
+  elseif action == "prev" then
+    navigate_changed(cwd, "prev")
+    return
+  end
+
+  if not path then
+    notify("Not inside a git repository")
+    return
+  end
+
+  ya.emit("cd", { path })
+end
+
+return { entry = entry }


### PR DESCRIPTION
This plugin adds enhanced Git navigation capabilities to Yazi, allowing users to jump between changed files/folders efficiently.

## Features
- Quick jump to next/previous modified file
- Quick jump to root-folder of the Git repository
- Quick jump to .git folder

## Checklist
- [x] I have tested this plugin locally
    * Yazi 26.1.4 (Arch Linux 2026-01-04)
    * git version 2.52.0
- [x] Documentation added to the README (if applicable)
