### PR TITLE
feat(smart-filter): add auto_enter and confirm_keys options

### DIFF
--- a/smart-filter.yazi/README.md
+++ b/smart-filter.yazi/README.md
@@ -23,6 +23,23 @@ desc = "Smart filter"
 
 Note that, the keybindings above are just examples, please tune them up as needed to ensure they don't conflict with your other actions/plugins.
 
+## Configuration
+
+Add this to your `~/.config/yazi/init.lua`:
+
+```lua
+require("smart-filter"):setup {
+  -- Set to false to disable automatically entering a directory when it's the
+  -- only match. Useful if you find the plugin enters directories mid-typing.
+  auto_enter = true,
+
+  -- Extra characters that confirm the current match (in addition to Enter):
+  -- enter a directory or open a file without closing the filter prompt first.
+  -- For example, { " " } makes Space act as a confirm key.
+  confirm_keys = {},
+}
+```
+
 ## License
 
 This plugin is MIT-licensed. For more information check the [LICENSE](LICENSE) file.


### PR DESCRIPTION
## Summary

- Adds `auto_enter` option (default `true`) to disable automatic directory entry when only one match remains. Useful when you type fast and the plugin enters a directory mid-streak.
- Adds `confirm_keys` option (default `{}`) to define extra characters that confirm the current match — entering a directory or opening a file — in addition to `<Enter>`. For example, `{ " " }` makes Space act as a confirm key.

Both options default to the original behavior, so this is fully backward-compatible.

## Example

```lua
-- ~/.config/yazi/init.lua
require("smart-filter"):setup {
  auto_enter   = false,   -- don't enter dirs mid-typing
  confirm_keys = { " " }, -- Space also confirms
}
```