### PR TITLE
smart-filter: prompt popup on top

### DIFF
--- a/smart-filter.yazi/main.lua
+++ b/smart-filter.yazi/main.lua
@@ -16,7 +16,7 @@ end)
 local function prompt()
 	return ya.input {
 		title = "Smart filter:",
-		pos = { "center", w = 50 },
+		pos = { "top", w = 50 },
 		realtime = true,
 		debounce = 0.1,
 	}


### PR DESCRIPTION
Just like yazi's `search` and `filter` popups, smart-filter popup should be on top as well (for consistency).