### PR TITLE
Add --smart flag to jump-to-char plugin

### DIFF
--- a/jump-to-char.yazi/main.lua
+++ b/jump-to-char.yazi/main.lua
@@ -24,7 +24,11 @@ return {
 
 		local kw = escape(cands[idx].on)
 		if changed(kw) then
-			ya.emit("find_do", { "^" .. kw })
+			if job.args.smart == true then
+				ya.emit("find_do", { smart = true, "^" .. kw })
+			else
+				ya.emit("find_do", { "^" .. kw })
+			end
 		else
 			ya.emit("find_arrow", {})
 		end


### PR DESCRIPTION
PR adds a `--smart` flag to the jump-to-char plugin. This was done mostly to fit my use case, but I thought I'd make it available just in case others want it. Should retain existing behavior without the flag present.

I trigger this with the following entry in `keymap.toml`:
```
{ on = "f",            run = "plugin jump-to-char -- --smart", desc = "Jump to letter" },
```