### PR TITLE
smart-filter: keep filter active on Enter when no unique match

### DIFF
--- a/smart-filter.yazi/main.lua
+++ b/smart-filter.yazi/main.lua
@@ -40,8 +40,10 @@ local function entry()
 			ya.emit("enter", {})
 			input = prompt()
 		elseif event == 1 then
-			ya.emit("escape", { filter = true })
-			ya.emit(h.is_dir and "enter" or "open", { h.url })
+			if h.unique then
+				ya.emit("escape", { filter = true })
+				ya.emit(h.is_dir and "enter" or "open", { h.url })
+			end
 			break
 		end
 	end


### PR DESCRIPTION
## Problem

When typing a filter query that matches multiple files (e.g. `.config` matching both `.config` and `.gitconfig`), pressing Enter immediately opens the currently hovered file rather than allowing the user to select the intended one. There is no way to navigate the filtered list to pick the exact match.

Fixes #156.

## Root cause

The `event == 1` (Enter) branch always called `escape --filter` (which clears the filter) and then opened/entered the hovered item, regardless of whether the filtered results had narrowed down to a unique entry.

## Fix

Only open/enter when there is a unique match. When Enter is pressed with multiple results remaining, simply close the smart-filter input prompt without clearing the filter — leaving the filtered list visible so the user can navigate it manually with arrow keys and press Enter on the correct item.

```diff
-		elseif event == 1 then
-			ya.emit("escape", { filter = true })
-			ya.emit(h.is_dir and "enter" or "open", { h.url })
-			break
+		elseif event == 1 then
+			if h.unique then
+				ya.emit("escape", { filter = true })
+				ya.emit(h.is_dir and "enter" or "open", { h.url })
+			end
+			break
```

## Behaviour after fix

- Type `.config` → two results remain → press Enter → smart-filter input closes, filtered list stays → navigate with arrows → press Enter on `.config`
- Single unique file → unchanged: Enter opens it immediately
- Single unique directory → unchanged: auto-entered while typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)