### PR TITLE
feat(vcs-files): include untracked files in results

### DIFF
--- a/vcs-files.yazi/main.lua
+++ b/vcs-files.yazi/main.lua
@@ -6,11 +6,19 @@ local function fail(content) return ya.notify { title = "VCS Files", content = c
 
 local function entry()
 	local root = root()
-	local output, err = Command("git"):cwd(tostring(root)):arg({ "diff", "--name-only", "HEAD" }):output()
-	if err then
-		return fail("Failed to run `git diff`, error: " .. err)
-	elseif not output.status.success then
-		return fail("Failed to run `git diff`, stderr: " .. output.stderr)
+
+	local diff_output, diff_err = Command("git"):cwd(tostring(root)):arg({ "diff", "--name-only", "HEAD" }):output()
+	if diff_err then
+		return fail("Failed to run `git diff`, error: " .. diff_err)
+	elseif not diff_output.status.success then
+		return fail("Failed to run `git diff`, stderr: " .. diff_output.stderr)
+	end
+
+	local untracked_output, untracked_err = Command("git"):cwd(tostring(root)):arg({ "ls-files", "--others", "--exclude-standard" }):output()
+	if untracked_err then
+		return fail("Failed to run `git ls-files`, error: " .. untracked_err)
+	elseif not untracked_output.status.success then
+		return fail("Failed to run `git ls-files`, stderr: " .. untracked_output.stderr)
 	end
 
 	local id = ya.id("ft")
@@ -19,12 +27,16 @@ local function entry()
 	ya.emit("update_files", { op = fs.op("part", { id = id, url = Url(cwd), files = {} }) })
 
 	local files = {}
-	for line in output.stdout:gmatch("[^\r\n]+") do
+	local seen = {}
+	for line in (diff_output.stdout .. untracked_output.stdout):gmatch("[^\r\n]+") do
+		if seen[line] then goto continue end
+		seen[line] = true
 		local url = cwd:join(line)
 		local cha = fs.cha(url, true)
 		if cha then
 			files[#files + 1] = File { url = url, cha = cha }
 		end
+		::continue::
 	end
 	ya.emit("update_files", { op = fs.op("part", { id = id, url = Url(cwd), files = files }) })
 	ya.emit("update_files", { op = fs.op("done", { id = id, url = cwd, cha = Cha { mode = tonumber("100644", 8) } }) })

--- a/vcs-files.yazi/main.lua
+++ b/vcs-files.yazi/main.lua
@@ -1,24 +1,58 @@
---- @since 26.1.22
+--- @since 26.5.6
 
 local root = ya.sync(function() return cx.active.current.cwd end)
 
-local function fail(content) return ya.notify { title = "VCS Files", content = content, timeout = 5, level = "error" } end
+local function fail(content)
+	return ya.notify { title = "VCS Files", content = tostring(content), timeout = 5, level = "error" }
+end
+
+---@param args string[]
+---@return (fun(): string)?
+---@return Error?
+local function output(root, args)
+	local output, err = Command("git"):cwd(tostring(root)):arg(args):output()
+	if err then
+		return nil, Err("Failed to run `git %s`, error: %s", table.concat(args, " "), err)
+	elseif not output.status.success then
+		return nil, Err("Failed to run `git %s`, stderr: %s", table.concat(args, " "), output.stderr)
+	else
+		return output.stdout:gmatch("[^\r\n]+")
+	end
+end
+
+---@param a fun(): string
+---@param b fun(): string
+---@return fun(): string
+local function merge(a, b)
+	local seen = {}
+	local function yield(s)
+		if not seen[s] then
+			seen[s] = true
+			coroutine.yield(s)
+		end
+	end
+
+	return ya.co(function()
+		for line in a do
+			yield(line)
+		end
+		for line in b do
+			yield(line)
+		end
+	end)
+end
 
 local function entry()
 	local root = root()
 
-	local diff_output, diff_err = Command("git"):cwd(tostring(root)):arg({ "diff", "--name-only", "HEAD" }):output()
-	if diff_err then
-		return fail("Failed to run `git diff`, error: " .. diff_err)
-	elseif not diff_output.status.success then
-		return fail("Failed to run `git diff`, stderr: " .. diff_output.stderr)
+	local tracked, err = output(root, { "diff", "--name-only", "HEAD" })
+	if err then
+		return fail(err)
 	end
 
-	local untracked_output, untracked_err = Command("git"):cwd(tostring(root)):arg({ "ls-files", "--others", "--exclude-standard" }):output()
-	if untracked_err then
-		return fail("Failed to run `git ls-files`, error: " .. untracked_err)
-	elseif not untracked_output.status.success then
-		return fail("Failed to run `git ls-files`, stderr: " .. untracked_output.stderr)
+	local untracked, err = output(root, { "ls-files", "--others", "--exclude-standard" })
+	if err then
+		return fail(err)
 	end
 
 	local id = ya.id("ft")
@@ -27,16 +61,12 @@ local function entry()
 	ya.emit("update_files", { op = fs.op("part", { id = id, url = Url(cwd), files = {} }) })
 
 	local files = {}
-	local seen = {}
-	for line in (diff_output.stdout .. untracked_output.stdout):gmatch("[^\r\n]+") do
-		if seen[line] then goto continue end
-		seen[line] = true
+	for line in merge(tracked, untracked) do
 		local url = cwd:join(line)
 		local cha = fs.cha(url, true)
 		if cha then
 			files[#files + 1] = File { url = url, cha = cha }
 		end
-		::continue::
 	end
 	ya.emit("update_files", { op = fs.op("part", { id = id, url = Url(cwd), files = files }) })
 	ya.emit("update_files", { op = fs.op("done", { id = id, url = cwd, cha = Cha { mode = tonumber("100644", 8) } }) })


### PR DESCRIPTION
Added new `untracked_output` list to show untracked files in the search command. Follows the pattern of the `diff_output` from prior implementation. Open to rewriting the `for line in (diff_output.stdout .. untracked_output.stdout)` for loop--I just like `continue`-ing on defensive if checks rather than having a lot of indented if-statements.

Closes #215 

## Screenshots

**`plugin vcs-files` now shows untracked files**

<img width="1786" height="1189" alt="image" src="https://github.com/user-attachments/assets/8da56cd7-a79e-46ef-91f8-c9dde53e5eca" />
