### PR TITLE
feat(git): separate staged and unstaged modified states

### DIFF
--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -40,9 +40,9 @@ group = "git"
 You can customize the [Style](https://yazi-rs.github.io/docs/configuration/theme#types.style) of the status sign with:
 
 - `[git].unknown` - status cannot/not yet determined
-- `[git].modified` - modified file
+- `[git].unstaged` - unstaged file
 - `[git].staged` - staged file
-- `[git].added` - added file
+- `[git].added` - staged new file
 - `[git].untracked` - untracked file
 - `[git].ignored` - ignored file
 - `[git].deleted` - deleted file
@@ -54,16 +54,16 @@ For example:
 ```toml
 # theme.toml / flavor.toml
 [git]
-modified = { fg = "blue" }
+unstaged = { fg = "blue" }
 deleted  = { fg = "red", bold = true }
 ```
 
 You can also customize the text of the status sign with:
 
 - `[git].unknown_sign` - status cannot/not yet determined
-- `[git].modified_sign` - modified file
+- `[git].unstaged_sign` - unstaged file
 - `[git].staged_sign` - staged file
-- `[git].added_sign` - added file
+- `[git].added_sign` - staged new file
 - `[git].untracked_sign` - untracked file
 - `[git].ignored_sign` - ignored file
 - `[git].deleted_sign` - deleted file
@@ -76,7 +76,7 @@ For example:
 # theme.toml / flavor.toml
 [git]
 unknown_sign  = " "
-modified_sign = "M"
+unstaged_sign = "M"
 deleted_sign  = "D"
 clean_sign    = "✔"
 ```

--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -40,11 +40,11 @@ group = "git"
 You can customize the [Style](https://yazi-rs.github.io/docs/configuration/theme#types.style) of the status sign with:
 
 - `[git].unknown` - status cannot/not yet determined
+- `[git].ignored` - ignored file
+- `[git].untracked` - untracked file
 - `[git].unstaged` - unstaged file
 - `[git].staged` - staged file
 - `[git].added` - staged new file
-- `[git].untracked` - untracked file
-- `[git].ignored` - ignored file
 - `[git].deleted` - deleted file
 - `[git].updated` - updated file
 - `[git].clean` - clean file
@@ -61,11 +61,11 @@ deleted  = { fg = "red", bold = true }
 You can also customize the text of the status sign with:
 
 - `[git].unknown_sign` - status cannot/not yet determined
+- `[git].ignored_sign` - ignored file
+- `[git].untracked_sign` - untracked file
 - `[git].unstaged_sign` - unstaged file
 - `[git].staged_sign` - staged file
 - `[git].added_sign` - staged new file
-- `[git].untracked_sign` - untracked file
-- `[git].ignored_sign` - ignored file
 - `[git].deleted_sign` - deleted file
 - `[git].updated_sign` - updated file
 - `[git].clean_sign` - clean file

--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -41,6 +41,7 @@ You can customize the [Style](https://yazi-rs.github.io/docs/configuration/theme
 
 - `[git].unknown` - status cannot/not yet determined
 - `[git].modified` - modified file
+- `[git].staged` - staged file
 - `[git].added` - added file
 - `[git].untracked` - untracked file
 - `[git].ignored` - ignored file
@@ -61,6 +62,7 @@ You can also customize the text of the status sign with:
 
 - `[git].unknown_sign` - status cannot/not yet determined
 - `[git].modified_sign` - modified file
+- `[git].staged_sign` - staged file
 - `[git].added_sign` - added file
 - `[git].untracked_sign` - untracked file
 - `[git].ignored_sign` - ignored file

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -11,7 +11,7 @@ local CODES = {
 	excluded = 99, -- ignored directory
 	ignored = 7, -- ignored file
 	untracked = 6,
-	modified = 5,
+	unstaged = 5,
 	staged = 4,
 	added = 3,
 	deleted = 2,
@@ -22,8 +22,8 @@ local CODES = {
 local PATTERNS = {
 	{ "!$", CODES.ignored },
 	{ "?$", CODES.untracked },
-	{ "^[MT] ", CODES.staged },
-	{ "[MT]", CODES.modified },
+	{ ".[MT]", CODES.unstaged },
+	{ "[MT] ", CODES.staged },
 	{ "[AC]", CODES.added },
 	{ "D", CODES.deleted },
 	{ "U", CODES.updated },
@@ -36,7 +36,7 @@ local function theme()
 		[CODES.unknown] = t.unknown or ui.Style(),
 		[CODES.ignored] = t.ignored or ui.Style():fg("darkgray"),
 		[CODES.untracked] = t.untracked or ui.Style():fg("magenta"),
-		[CODES.modified] = t.modified or ui.Style():fg("yellow"),
+		[CODES.unstaged] = t.unstaged or ui.Style():fg("yellow"),
 		[CODES.staged] = t.staged or ui.Style():fg("green"),
 		[CODES.added] = t.added or ui.Style():fg("green"),
 		[CODES.deleted] = t.deleted or ui.Style():fg("red"),
@@ -46,7 +46,7 @@ local function theme()
 		[CODES.unknown] = t.unknown_sign or "",
 		[CODES.ignored] = t.ignored_sign or " ",
 		[CODES.untracked] = t.untracked_sign or "? ",
-		[CODES.modified] = t.modified_sign or " ",
+		[CODES.unstaged] = t.unstaged_sign or " ",
 		[CODES.staged] = t.staged_sign or " ",
 		[CODES.added] = t.added_sign or " ",
 		[CODES.deleted] = t.deleted_sign or " ",

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -9,9 +9,10 @@ local WINDOWS = ya.target_family() == "windows"
 local CODES = {
 	unknown = 100, -- status cannot/not yet determined
 	excluded = 99, -- ignored directory
-	ignored = 6, -- ignored file
-	untracked = 5,
-	modified = 4,
+	ignored = 7, -- ignored file
+	untracked = 6,
+	modified = 5,
+	staged = 4,
 	added = 3,
 	deleted = 2,
 	updated = 1,
@@ -21,6 +22,7 @@ local CODES = {
 local PATTERNS = {
 	{ "!$", CODES.ignored },
 	{ "?$", CODES.untracked },
+	{ "^[MT] ", CODES.staged },
 	{ "[MT]", CODES.modified },
 	{ "[AC]", CODES.added },
 	{ "D", CODES.deleted },
@@ -35,6 +37,7 @@ local function theme()
 		[CODES.ignored] = t.ignored or ui.Style():fg("darkgray"),
 		[CODES.untracked] = t.untracked or ui.Style():fg("magenta"),
 		[CODES.modified] = t.modified or ui.Style():fg("yellow"),
+		[CODES.staged] = t.staged or ui.Style():fg("green"),
 		[CODES.added] = t.added or ui.Style():fg("green"),
 		[CODES.deleted] = t.deleted or ui.Style():fg("red"),
 		[CODES.updated] = t.updated or ui.Style():fg("yellow"),
@@ -44,6 +47,7 @@ local function theme()
 		[CODES.ignored] = t.ignored_sign or " ",
 		[CODES.untracked] = t.untracked_sign or "? ",
 		[CODES.modified] = t.modified_sign or " ",
+		[CODES.staged] = t.staged_sign or " ",
 		[CODES.added] = t.added_sign or " ",
 		[CODES.deleted] = t.deleted_sign or " ",
 		[CODES.updated] = t.updated_sign or " ",

--- a/git.yazi/types.lua
+++ b/git.yazi/types.lua
@@ -4,7 +4,7 @@
 
 ---@class Options
 ---@field order number The order in which the status is displayed
----@field renamed boolean Whether to include renamed files in the status (or treat them as modified)
+---@field renamed boolean Whether to include renamed files in the status (or treat them as unstaged)
 
 -- TODO: move this to `types.yazi` once it's get stable
 ---@alias UnstableFetcher fun(self: unknown, job: { files: File[] }): boolean, Error?


### PR DESCRIPTION
Currently, `git.yazi` maps both staged (`M `) and unstaged (` M`) modifications to a single `CODES.modified` status, rendering them identically in the UI. 

This PR separates these two states to allow users to visually distinguish between staged (ready to commit) and unstaged changes.

**Changes:**
1. **Added `staged` status code** to the `CODES` enum and adjusted priorities, preserving proper directory status propagation (`bubble_up`).
2. **Updated status parsing pattern** to match staged modifications (`^[MT] `) first, mapping them to the new `staged` status. Unstaged (or mixed `MM`) modifications continue to fall back to `modified`.
3. **Defaulted staged files to green** while inheriting the existing `modified_sign`.
4. **Documented `staged` and `staged_sign`** options in `README.md`.

Example:
<img width="674" height="223" alt="image" src="https://github.com/user-attachments/assets/8ae5c978-760c-4dd8-be1e-f33a639c10e9" />
