### PR TITLE
fix(smart-filter): adjust vertical position of the plugin

### DIFF
--- a/smart-filter.yazi/main.lua
+++ b/smart-filter.yazi/main.lua
@@ -16,7 +16,7 @@ end)
 local function prompt()
 	return ya.input {
 		title = "Smart filter:",
-		pos = { "top-center", w = 50 },
+		pos = { "top-center", y = 2, w = 50 },
 		realtime = true,
 		debounce = 0.1,
 	}


### PR DESCRIPTION
After Commit cf2c6d8, the `smart-filter` prompt position was changed to `top-center`. However, its vertical position is still slightly off — it appears a bit too high compared to other prompts like `fd`, `rg`, and `filter`.

The vertical position of `smart-filter` should be perfectly aligned with `fd`, `rg`, `filter`.

**Before**

<img width="1452" height="498" alt="image" src="https://github.com/user-attachments/assets/1f78fc27-43e1-4c72-92d9-e634c800a404" />



**After**


<img width="724" height="229" alt="PixPin_2026-07-04_13-00-12" src="https://github.com/user-attachments/assets/91073a8e-1ec2-45b1-9ef0-0e9ebd4b7fea" />
