### PR TITLE
feat: add latest-session.yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For specific installation commands and configuration instructions, check the ind
 - [types.yazi](types.yazi) - Type definitions for Yazi's Lua API, empowering an efficient plugin development experience.
 - [zoom.yazi](zoom.yazi) - Zoom in or out of the preview image.
 - [smart-filter.yazi](smart-filter.yazi) - Makes filters smarter: continuous filtering, automatically enter unique directory, open file on submitting.
+- [latest-session.yazi](latest-session.yazi) - Save and restore the latest tabs.
 - [chmod.yazi](chmod.yazi) - Execute `chmod` on the selected files to change their mode.
 - [mime-ext.yazi](mime-ext.yazi) - A mime-type provider based on a file extension database, replacing the builtin `file(1)` to speed up mime-type retrieval at the expense of accuracy.
 - [smart-paste.yazi](smart-paste.yazi) - Paste files into the hovered directory or to the CWD if hovering over a file.

--- a/latest-session.yazi/LICENSE
+++ b/latest-session.yazi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 yazi-rs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/latest-session.yazi/README.md
+++ b/latest-session.yazi/README.md
@@ -1,0 +1,59 @@
+# latest-session.yazi
+
+Save and restore the latest Yazi tabs.
+
+## Features
+
+- Save the current tabs before quitting.
+- Restore the latest saved tabs on startup.
+- Skip directories that no longer exist.
+- Save only tab directories and the active tab index.
+
+## Installation
+
+```sh
+ya pkg add yazi-rs/plugins:latest-session
+```
+
+## Usage
+
+Add this to your `~/.config/yazi/init.lua`:
+
+```lua
+require("latest-session"):setup()
+```
+
+Bind quit and close actions in your `~/.config/yazi/keymap.toml`:
+
+```toml
+[[mgr.prepend_keymap]]
+on   = "q"
+run  = "plugin latest-session -- close"
+desc = "Close tab, or save tabs and quit"
+
+[[mgr.prepend_keymap]]
+on   = "<C-c>"
+run  = "plugin latest-session -- quit"
+desc = "Save tabs and quit"
+```
+
+## Commands
+
+- `save` - Save the current tabs.
+- `restore` - Restore the latest saved tabs.
+- `quit` - Save the current tabs and quit Yazi.
+- `close` - Close the current tab, or save and quit if it is the last tab.
+
+## Session file
+
+The session is stored at:
+
+```text
+${XDG_STATE_HOME:-~/.local/state}/yazi/latest-session.lua
+```
+
+The session file only stores each tab's directory and the active tab index. It does not store hovered files, selections, filters, sorting, or other UI state.
+
+## License
+
+This plugin is MIT-licensed. For more information check the [LICENSE](LICENSE) file.

--- a/latest-session.yazi/main.lua
+++ b/latest-session.yazi/main.lua
@@ -1,0 +1,218 @@
+--- @since 26.5.6
+
+local M = {}
+
+local function expand_tilde(path)
+  if path == "~" then
+    return os.getenv("HOME") or ""
+  end
+
+  if path:sub(1, 2) == "~/" then
+    return (os.getenv("HOME") or "") .. path:sub(2)
+  end
+
+  return path
+end
+
+local function state_dir()
+  local base = os.getenv("XDG_STATE_HOME")
+  if not base or base == "" then
+    base = expand_tilde("~/.local/state")
+  end
+
+  return base .. "/yazi"
+end
+
+local function session_file()
+  return state_dir() .. "/latest-session.lua"
+end
+
+local function notify(content, level)
+  ya.notify {
+    title = "latest-session",
+    content = content,
+    timeout = 5,
+    level = level or "info",
+  }
+end
+
+local function serialize_session(session)
+  local lines = {
+    "return {",
+    string.format("  active_idx = %d,", session.active_idx or 1),
+    "  tabs = {",
+  }
+
+  for _, tab in ipairs(session.tabs or {}) do
+    table.insert(lines, string.format("    { cwd = %q },", tab.cwd))
+  end
+
+  table.insert(lines, "  },")
+  table.insert(lines, "}")
+  table.insert(lines, "")
+  return table.concat(lines, "\n")
+end
+
+local function is_dir(path)
+  if type(path) ~= "string" or path == "" then
+    return false
+  end
+
+  local ok, cha = pcall(function()
+    return fs.cha(Url(path))
+  end)
+
+  return ok and cha and cha.is_dir
+end
+
+local function load_session()
+  local chunk = loadfile(session_file())
+  if not chunk then
+    return nil
+  end
+
+  local ok, session = pcall(chunk)
+  if not ok then
+    return nil
+  end
+
+  return session
+end
+
+local function valid_session(session)
+  local result = {
+    active_idx = 1,
+    tabs = {},
+  }
+
+  if type(session) ~= "table" or type(session.tabs) ~= "table" then
+    return result
+  end
+
+  local saved_active_idx = tonumber(session.active_idx) or 1
+  for idx, tab in ipairs(session.tabs) do
+    if type(tab) == "table" and is_dir(tab.cwd) then
+      table.insert(result.tabs, { cwd = tab.cwd })
+      if idx <= saved_active_idx then
+        result.active_idx = #result.tabs
+      end
+    end
+  end
+
+  return result
+end
+
+local read_current_session = ya.sync(function()
+  local session = {
+    active_idx = cx.tabs.idx,
+    tabs = {},
+  }
+
+  for _, tab in ipairs(cx.tabs) do
+    if tab.current and tab.current.cwd then
+      table.insert(session.tabs, {
+        cwd = tostring(tab.current.cwd):gsub("\\", "/"),
+      })
+    end
+  end
+
+  if #session.tabs == 0 and cx.active.current.cwd then
+    table.insert(session.tabs, {
+      cwd = tostring(cx.active.current.cwd):gsub("\\", "/"),
+    })
+    session.active_idx = 1
+  end
+
+  return session
+end)
+
+local tab_count = ya.sync(function()
+  return #cx.tabs
+end)
+
+local restore_session = ya.sync(function(_, session)
+  local tabs = session.tabs
+  if not tabs or #tabs == 0 then
+    return
+  end
+
+  ya.emit("cd", { tabs[1].cwd, raw = true })
+
+  for i = 2, #tabs do
+    ya.emit("tab_create", { tabs[i].cwd })
+  end
+
+  local active_idx = math.max(1, math.min(session.active_idx or 1, #tabs))
+  ya.emit("tab_switch", { active_idx - 1 })
+end)
+
+function M:save()
+  local session = read_current_session()
+  if not session or #session.tabs == 0 then
+    return false, "No tabs to save"
+  end
+
+  local ok, err = fs.create("dir_all", Url(state_dir()))
+  if not ok then
+    return false, err
+  end
+
+  local file
+  file, err = io.open(session_file(), "w")
+  if not file then
+    return false, err
+  end
+
+  file:write(serialize_session(session))
+  file:close()
+  return true
+end
+
+function M:restore()
+  local session = valid_session(load_session())
+  if #session.tabs == 0 then
+    return
+  end
+
+  restore_session(session)
+end
+
+function M:quit()
+  local ok, err = self:save()
+  if not ok then
+    notify("Cannot save tabs: " .. tostring(err), "error")
+  end
+
+  ya.emit("quit", {})
+end
+
+function M:close()
+  if tab_count() <= 1 then
+    self:quit()
+  else
+    ya.emit("close", {})
+  end
+end
+
+function M:setup()
+  self:restore()
+end
+
+function M:entry(job)
+  local action = job.args[1]
+
+  if action == "save" then
+    local ok, err = self:save()
+    if not ok then
+      notify("Cannot save tabs: " .. tostring(err), "error")
+    end
+  elseif action == "quit" then
+    self:quit()
+  elseif action == "close" then
+    self:close()
+  elseif action == "restore" then
+    self:restore()
+  end
+end
+
+return M


### PR DESCRIPTION
## Summary

Adds `latest-session.yazi`, a small plugin that saves and restores the latest Yazi tabs.

It can:

- Restore saved tabs on startup with `require("latest-session"):setup()`.
- Save and quit via `plugin latest-session -- quit`.
- Close the current tab, or save and quit when it is the last tab, via `plugin latest-session -- close`.
- Manually save or restore via `save` and `restore`.

The session file is stored under `${XDG_STATE_HOME:-~/.local/state}/yazi/latest-session.lua`.

## Notes

Only tab directories and the active tab index are saved. Hovered files, selections, filters, sorting, and other UI state are intentionally not stored.

## Testing

- `git diff --check upstream/main..HEAD`

Manual runtime testing not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)