### PR TITLE
feat(git): optionally style filenames by git status

### DIFF
--- a/git.yazi/README.md
+++ b/git.yazi/README.md
@@ -18,6 +18,9 @@ Add the following to your `~/.config/yazi/init.lua`:
 require("git"):setup {
 	-- Order of status signs showing in the linemode
 	order = 1500,
+
+	-- Whether to style filenames based on Git status
+	style_filename = false,
 }
 ```
 
@@ -58,6 +61,16 @@ For example:
 modified = { fg = "blue" }
 deleted  = { fg = "red", bold = true }
 ```
+
+You can also apply Git status styles to filenames:
+
+```lua
+require("git"):setup {
+	style_filename = true,
+}
+```
+
+It reuses the corresponding `[git]` styles from your theme. This is disabled by default, and clean files keep their regular filename style.
 
 You can also customize the text of the status sign with:
 

--- a/git.yazi/main.lua
+++ b/git.yazi/main.lua
@@ -183,17 +183,41 @@ local function setup(st, opts)
 		[CODES.clean] = t.clean_sign or "",
 	}
 
+	local function file_code(file)
+		local url = file.url
+		local repo = st.dirs[tostring(url.base or url.parent)]
+		if not repo then
+			return CODES.unknown
+		elseif repo == CODES.excluded then
+			return CODES.ignored
+		end
+
+		return st.repos[repo][tostring(url):sub(#repo + 2)] or CODES.clean
+	end
+
+	if opts.style_filename and Entity then
+		local style = Entity.style
+		Entity.style = function(self)
+			local base = style(self) or ui.Style()
+			local file = self._file
+			if not file then
+				return base
+			end
+
+			local code = file_code(file)
+			if code == CODES.clean then
+				return base
+			end
+			return base:patch(styles[code])
+		end
+	end
+
 	Linemode:children_add(function(self)
 		if not self._file.in_current then
 			return ""
 		end
 
-		local url = self._file.url
-		local repo = st.dirs[tostring(url.base or url.parent)]
-		local code = CODES.unknown
-		if repo then
-			code = repo == CODES.excluded and CODES.ignored or st.repos[repo][tostring(url):sub(#repo + 2)] or CODES.clean
-		end
+		local code = file_code(self._file)
 
 		if signs[code] == "" then
 			return ""

--- a/git.yazi/types.lua
+++ b/git.yazi/types.lua
@@ -5,6 +5,7 @@
 ---@class Options
 ---@field order number The order in which the status is displayed
 ---@field renamed boolean Whether to include renamed files in the status (or treat them as modified)
+---@field style_filename boolean Whether to style filenames based on Git status
 
 -- TODO: move this to `types.yazi` once it's get stable
 ---@alias UnstableFetcher fun(self: unknown, job: { files: File[] }): boolean, Error?


### PR DESCRIPTION
## Summary
- add an opt-in `style_filename` option for `git.yazi`
- reuse existing `[git]` theme styles for non-clean filenames
- keep default behaviour unchanged and leave status parsing untouched

## Notes
- clean files keep their regular filename style
- this does not change `CODES`, `PATTERNS`, or the git status parser, so it should stay compatible with #218

## Test plan
- `git diff --check`
- `stylua --check` not run: `stylua` is not installed locally
- manual runtime testing not run locally