### PR TITLE
Add brace plugin: Bash-like brace expansion for Yazi

### DIFF
--- a/brace.yazi/LICENSE
+++ b/brace.yazi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hastagaming
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/brace.yazi/README.md
+++ b/brace.yazi/README.md
@@ -1,0 +1,61 @@
+# brace.yazi
+
+Yazi plugin for creating directories using Bash-like brace expansion — pure Lua,
+no shell calls, no external dependencies.
+
+## Features
+
+- **Comma list**: `project/{src,include,docs,tests}`
+- **Nested braces**: `project/{src/{main,test},docs}`
+- **Numeric ranges** (with zero-padding & reverse): `chapter{1..5}`, `img{01..03}`
+- **Alphabetic ranges**: `{A..D}`, `{a..d}`
+- **Cartesian product**: `{android,desktop}/{debug,release}`
+- **Recursive mkdir** (`mkdir -p` equivalent) using Yazi's filesystem API
+- **Preview before execution** with Enter/Esc confirmation
+- **Clear error messages** for invalid patterns — no crashes
+
+## Installation
+
+```bash
+ya pkg add brace
+```
+Or with author prefix:
+```bash
+ya pkg add hastagaming/brace
+```
+
+## Keymap Configuration
+
+in keymap.toml, add this key:
+```bash
+[[manager.prepend_keymap]]
+on   = ["c", "b"]
+run  = "plugin brace"
+desc = "Create directories with brace expansion"
+```
+Press c then b inside Yazi to open the brace expansion prompt.
+
+## Usage
+
+- 1.Press cb in Yazi.
+- 2.Type a pattern, e.g.:
+    ```Code
+    project/{src,include,docs,tests}
+    ```
+- 3.Plugin displays a preview and asks for confirmation.
+- 4.Press Enter to create, Esc or CTRL + c to cancel.
+
+## Supported Patterns
+
+|Pattern | Output|
+|---|---|
+|project/{src,include,docs} | project/src, project/include, project/docs|<
+|project/{src/{main,test},docs} | project/src/main, project/src/test, project/docs|
+|chapter{1..5} | chapter1, chapter2, ..., chapter5|
+|img{01..05} | img01, img02, ..., img05|
+|{A..D} | A, B, C, D|
+|{a..d} | a, b, c, d|
+|{ios,android}/{arm64,x86} | ios/arm64, ios/x86, android/arm64, android/x86|
+
+## License
+see the [MIT](./LICENSE) License

--- a/brace.yazi/fs.lua
+++ b/brace.yazi/fs.lua
@@ -1,0 +1,42 @@
+-- fs.lua
+-- Filesystem operations for brace.yazi.
+-- Uses Yazi's built-in `fs` API only — no shell, no external processes.
+local Fs = {}
+
+-- Create a single directory, including any missing parent directories
+-- (equivalent to `mkdir -p`). Returns true on success, or false + error
+-- string on failure. Already-existing directories are treated as success.
+function Fs.mkdir_p(path)
+	local url = Url(path)
+	local ok, err = fs.create("dir_all", url)
+	if ok then
+		return true
+	end
+
+	-- If it already exists as a directory, that's not a real failure.
+	local cha = fs.cha(url, false)
+	if cha and cha.is_dir then
+		return true
+	end
+
+	return false, tostring(err or "unknown filesystem error")
+end
+
+-- Create every directory in `paths` (a list of absolute path strings).
+-- Returns two lists: successfully created paths, and { path, error } failures.
+function Fs.create_all(paths)
+	local created, failed = {}, {}
+
+	for _, path in ipairs(paths) do
+		local ok, err = Fs.mkdir_p(path)
+		if ok then
+			created[#created + 1] = path
+		else
+			failed[#failed + 1] = { path = path, error = err }
+		end
+	end
+
+	return created, failed
+end
+
+return Fs

--- a/brace.yazi/init.lua
+++ b/brace.yazi/init.lua
@@ -1,0 +1,10 @@
+-- init.lua
+-- Entry point for brace.yazi.
+-- Yazi loads this when the plugin is invoked, e.g. via `plugin brace` in keymap.toml.
+local Main = require("main")
+
+return {
+	entry = function()
+		Main.run()
+	end,
+}

--- a/brace.yazi/main.lua
+++ b/brace.yazi/main.lua
@@ -1,0 +1,86 @@
+-- main.lua
+-- Orchestrates the full brace.yazi flow: prompt -> parse -> preview -> create.
+local Parser = require("parser")
+local Fs = require("fs")
+local Preview = require("preview")
+local Util = require("util")
+
+local Main = {}
+
+-- Ask the user for a brace-expansion pattern.
+-- Returns the raw pattern string, or nil if the user cancelled.
+local function prompt_pattern()
+	local value, event = ya.input({
+		title = "Create (brace expansion):",
+		position = { "top-center", y = 3, w = 50 },
+	})
+
+	if event ~= 1 or Util.is_blank(value) then
+		return nil
+	end
+
+	return Util.trim(value)
+end
+
+-- Resolve a list of relative paths against the current working directory.
+local function resolve_paths(cwd, relatives)
+	local base = tostring(cwd):gsub("/+$", "")
+	local absolute = {}
+	for _, rel in ipairs(relatives) do
+		absolute[#absolute + 1] = base .. "/" .. rel
+	end
+	return absolute
+end
+
+function Main.run()
+	local pattern = prompt_pattern()
+	if not pattern then
+		return
+	end
+
+	local expanded, err = Parser.expand(pattern)
+	if not expanded then
+		ya.notify({
+			title = "brace.yazi: invalid pattern",
+			content = err,
+			level = "error",
+			timeout = 5,
+		})
+		return
+	end
+
+	expanded = Util.sort(Util.dedup(expanded))
+
+	local cwd = cx.active.current.cwd
+	local absolute_paths = resolve_paths(cwd, expanded)
+
+	if not Preview.confirm(expanded) then
+		return
+	end
+
+	local created, failed = Fs.create_all(absolute_paths)
+
+	if #failed == 0 then
+		ya.notify({
+			title = "brace.yazi",
+			content = string.format("Created %d %s.", #created, #created == 1 and "directory" or "directories"),
+			level = "info",
+			timeout = 3,
+		})
+	else
+		local lines = {}
+		for _, f in ipairs(failed) do
+			lines[#lines + 1] = f.path .. ": " .. f.error
+		end
+		ya.notify({
+			title = string.format("brace.yazi: %d failed", #failed),
+			content = table.concat(lines, "\n"),
+			level = "error",
+			timeout = 8,
+		})
+	end
+
+	ya.manager_emit("refresh", {})
+end
+
+return Main

--- a/brace.yazi/package.toml
+++ b/brace.yazi/package.toml
@@ -1,0 +1,52 @@
+[package]
+name = "brace"
+version = "0.1.0"
+description = "Bash-like brace expansion for creating directories in Yazi"
+keywords = ["brace", "expansion", "mkdir", "directory"]
+authors = ["Komandan Nasa"]
+homepage = "https://github.com/hastagaming/brace.yazi"
+repository = "https://github.com/hastagaming/brace.yazi"
+license = "MIT"
+
+[package.dependencies]
+
+[package.build]
+script = ""
+
+[package.hooks]
+pre_install = ""
+post_install = ""
+pre_remove = ""
+post_remove = ""
+
+[[package.files]]
+path = "init.lua"
+desc = "Entry point"
+
+[[package.files]]
+path = "main.lua"
+desc = "Main orchestration"
+
+[[package.files]]
+path = "parser.lua"
+desc = "Brace expansion parser"
+
+[[package.files]]
+path = "fs.lua"
+desc = "Filesystem operations"
+
+[[package.files]]
+path = "preview.lua"
+desc = "Preview and confirmation UI"
+
+[[package.files]]
+path = "util.lua"
+desc = "Utility functions"
+
+[[package.files]]
+path = "README.md"
+desc = "Documentation"
+
+[[package.files]]
+path = "LICENSE"
+desc = "MIT License"

--- a/brace.yazi/parser.lua
+++ b/brace.yazi/parser.lua
@@ -1,0 +1,206 @@
+-- parser.lua
+-- Pure Lua brace expansion parser (Bash-like), no shell dependency.
+local Parser = {}
+
+-- Find the first "{" in `str` and the position of its matching "}".
+-- Returns start_pos, end_pos (both 1-based, inclusive).
+-- If the opening brace has no matching close, end_pos is nil.
+local function find_matching_brace(str)
+	local start_pos = str:find("{", 1, true)
+	if not start_pos then
+		return nil
+	end
+
+	local depth = 0
+	local i = start_pos
+	local len = #str
+	while i <= len do
+		local c = str:sub(i, i)
+		if c == "{" then
+			depth = depth + 1
+		elseif c == "}" then
+			depth = depth - 1
+			if depth == 0 then
+				return start_pos, i
+			end
+		end
+		i = i + 1
+	end
+
+	return start_pos, nil -- unbalanced: opening found, no matching close
+end
+
+-- Split `body` on top-level commas (commas not nested inside inner braces).
+local function split_top_level(body)
+	local parts = {}
+	local depth = 0
+	local buf = {}
+
+	for i = 1, #body do
+		local c = body:sub(i, i)
+		if c == "{" then
+			depth = depth + 1
+			buf[#buf + 1] = c
+		elseif c == "}" then
+			depth = depth - 1
+			buf[#buf + 1] = c
+		elseif c == "," and depth == 0 then
+			parts[#parts + 1] = table.concat(buf)
+			buf = {}
+		else
+			buf[#buf + 1] = c
+		end
+	end
+	parts[#parts + 1] = table.concat(buf)
+
+	return parts
+end
+
+-- Try to parse `body` as a numeric range, e.g. "1..5", "05..01".
+-- Preserves zero-padding width when either bound has a leading zero.
+local function try_numeric_range(body)
+	local a, b = body:match("^(%-?%d+)%.%.(%-?%d+)$")
+	if not a then
+		return nil
+	end
+
+	local pad = false
+	local width = 0
+	if a:match("^%-?0%d") or b:match("^%-?0%d") then
+		pad = true
+		width = math.max(#a, #b)
+	end
+
+	local from, to = tonumber(a), tonumber(b)
+	local step = from <= to and 1 or -1
+	local values = {}
+
+	local n = from
+	while true do
+		local s = tostring(math.abs(n))
+		if pad then
+			s = string.rep("0", math.max(0, width - #s)) .. s
+		end
+		if n < 0 then
+			s = "-" .. s
+		end
+		values[#values + 1] = s
+		if n == to then
+			break
+		end
+		n = n + step
+	end
+
+	return values
+end
+
+-- Try to parse `body` as a single-character alphabetic range, e.g. "a..d".
+local function try_alpha_range(body)
+	local a, b = body:match("^(%a)%.%.(%a)$")
+	if not a then
+		return nil
+	end
+
+	local from, to = string.byte(a), string.byte(b)
+	local step = from <= to and 1 or -1
+	local values = {}
+
+	local n = from
+	while true do
+		values[#values + 1] = string.char(n)
+		if n == to then
+			break
+		end
+		n = n + step
+	end
+
+	return values
+end
+
+-- Recursively expand a single pattern string.
+-- Returns a list of expanded strings, or nil + error message on failure.
+local function expand(str)
+	local start_pos, end_pos = find_matching_brace(str)
+
+	if not start_pos then
+		return { str }
+	end
+
+	if not end_pos then
+		return nil, "unbalanced brace: missing '}' for '{' at position " .. start_pos
+	end
+
+	local prefix = str:sub(1, start_pos - 1)
+	local body = str:sub(start_pos + 1, end_pos - 1)
+	local suffix = str:sub(end_pos + 1)
+
+	local suffix_expanded, serr = expand(suffix)
+	if not suffix_expanded then
+		return nil, serr
+	end
+
+	-- A brace group is either a range, a comma-list, or (if neither) literal text.
+	local atoms = try_numeric_range(body) or try_alpha_range(body)
+
+	if not atoms then
+		local parts = split_top_level(body)
+		if #parts > 1 then
+			atoms = parts
+		else
+			-- Not valid brace syntax (e.g. "{foo}") — bash keeps it literal.
+			local literal_result = {}
+			for _, se in ipairs(suffix_expanded) do
+				literal_result[#literal_result + 1] = prefix .. "{" .. body .. "}" .. se
+			end
+			return literal_result
+		end
+	end
+
+	local results = {}
+	for _, atom in ipairs(atoms) do
+		local atom_expanded, aerr = expand(atom)
+		if not atom_expanded then
+			return nil, aerr
+		end
+		for _, ae in ipairs(atom_expanded) do
+			for _, se in ipairs(suffix_expanded) do
+				results[#results + 1] = prefix .. ae .. se
+			end
+		end
+	end
+
+	return results
+end
+
+-- Public entry point.
+-- Returns a list of expanded path strings, or nil + error message.
+function Parser.expand(input)
+	if type(input) ~= "string" or input == "" then
+		return nil, "empty pattern"
+	end
+
+	-- Quick top-level balance check for a clear, early error message.
+	local open_count, close_count = 0, 0
+	for c in input:gmatch("[{}]") do
+		if c == "{" then
+			open_count = open_count + 1
+		else
+			close_count = close_count + 1
+		end
+	end
+	if open_count ~= close_count then
+		return nil, "unbalanced braces: " .. open_count .. " '{' vs " .. close_count .. " '}'"
+	end
+
+	local ok, result_or_err, err = pcall(expand, input)
+	if not ok then
+		return nil, "parser error: " .. tostring(result_or_err)
+	end
+	if not result_or_err then
+		return nil, err
+	end
+
+	return result_or_err
+end
+
+return Parser

--- a/brace.yazi/preview.lua
+++ b/brace.yazi/preview.lua
@@ -1,0 +1,49 @@
+-- preview.lua
+-- Shows a preview of the directories that will be created and asks the
+-- user to confirm via Yazi's own input popup (Enter = create, Esc = cancel).
+local Preview = {}
+
+local MAX_LINES = 20
+
+-- Build a human-readable preview body from a list of paths.
+local function build_body(paths)
+	local lines = {}
+	for i, path in ipairs(paths) do
+		if i > MAX_LINES then
+			lines[#lines + 1] = string.format("  ... and %d more", #paths - MAX_LINES)
+			break
+		end
+		lines[#lines + 1] = "  \xe2\x9c\x93 " .. path -- "✓ path"
+	end
+	return table.concat(lines, "\n")
+end
+
+-- Show the preview notification and ask the user to confirm.
+-- Returns true if the user pressed Enter, false if cancelled or Esc.
+function Preview.confirm(paths)
+	if #paths == 0 then
+		ya.notify({
+			title = "brace.yazi",
+			content = "Nothing to create.",
+			level = "warn",
+			timeout = 3,
+		})
+		return false
+	end
+
+	ya.notify({
+		title = string.format("Will create %d %s", #paths, #paths == 1 and "directory" or "directories"),
+		content = build_body(paths),
+		level = "info",
+		timeout = 6,
+	})
+
+	local _, event = ya.input({
+		title = "Press Enter to create, Esc to cancel",
+		position = { "top-center", y = 3, w = 60 },
+	})
+
+	return event == 1
+end
+
+return Preview

--- a/brace.yazi/tests/cartesian_test.lua
+++ b/brace.yazi/tests/cartesian_test.lua
@@ -1,0 +1,49 @@
+-- tests/cartesian_test.lua
+-- Run with: cd tests && lua cartesian_test.lua
+package.path = "../?.lua;./?.lua;" .. package.path
+local Parser = require("parser")
+
+local pass, fail = 0, 0
+
+local function eq_list(a, b)
+	if not a or #a ~= #b then
+		return false
+	end
+	for i = 1, #a do
+		if a[i] ~= b[i] then
+			return false
+		end
+	end
+	return true
+end
+
+local function check(name, got, want)
+	if eq_list(got, want) then
+		pass = pass + 1
+		print("  ok   " .. name)
+	else
+		fail = fail + 1
+		print("  FAIL " .. name)
+		print("        got:  " .. table.concat(got or {}, ", "))
+		print("        want: " .. table.concat(want, ", "))
+	end
+end
+
+print("cartesian_test.lua")
+
+check("basic cartesian", Parser.expand("{android,desktop}/{debug,release}"), {
+	"android/debug", "android/release", "desktop/debug", "desktop/release",
+})
+
+check("triple cartesian", Parser.expand("{a,b}/{c,d}/{e,f}"), {
+	"a/c/e", "a/c/f", "a/d/e", "a/d/f",
+	"b/c/e", "b/c/f", "b/d/e", "b/d/f",
+})
+
+check("cartesian with literal glue", Parser.expand("build/{ios,android}-{arm64,x86}"), {
+	"build/ios-arm64", "build/ios-x86",
+	"build/android-arm64", "build/android-x86",
+})
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/brace.yazi/tests/nested_test.lua
+++ b/brace.yazi/tests/nested_test.lua
@@ -1,0 +1,47 @@
+-- tests/nested_test.lua
+-- Run with: cd tests && lua nested_test.lua
+package.path = "../?.lua;./?.lua;" .. package.path
+local Parser = require("parser")
+
+local pass, fail = 0, 0
+
+local function eq_list(a, b)
+	if not a or #a ~= #b then
+		return false
+	end
+	for i = 1, #a do
+		if a[i] ~= b[i] then
+			return false
+		end
+	end
+	return true
+end
+
+local function check(name, got, want)
+	if eq_list(got, want) then
+		pass = pass + 1
+		print("  ok   " .. name)
+	else
+		fail = fail + 1
+		print("  FAIL " .. name)
+		print("        got:  " .. table.concat(got or {}, ", "))
+		print("        want: " .. table.concat(want, ", "))
+	end
+end
+
+print("nested_test.lua")
+
+check("basic nested", Parser.expand("project/{src/{main,test},docs}"), {
+	"project/src/main", "project/src/test", "project/docs",
+})
+
+check("deep nested", Parser.expand("a/{b/{c,d},e/{f,g}}"), {
+	"a/b/c", "a/b/d", "a/e/f", "a/e/g",
+})
+
+check("nested with range", Parser.expand("ch{1..2}/{intro,body}"), {
+	"ch1/intro", "ch1/body", "ch2/intro", "ch2/body",
+})
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/brace.yazi/tests/parser_test.lua
+++ b/brace.yazi/tests/parser_test.lua
@@ -1,0 +1,57 @@
+-- tests/parser_test.lua
+-- Run with: cd tests && lua parser_test.lua
+package.path = "../?.lua;./?.lua;" .. package.path
+local Parser = require("parser")
+
+local pass, fail = 0, 0
+
+local function eq_list(a, b)
+	if not a or #a ~= #b then
+		return false
+	end
+	for i = 1, #a do
+		if a[i] ~= b[i] then
+			return false
+		end
+	end
+	return true
+end
+
+local function check(name, got, want)
+	if eq_list(got, want) then
+		pass = pass + 1
+		print("  ok   " .. name)
+	else
+		fail = fail + 1
+		print("  FAIL " .. name)
+		print("        got:  " .. table.concat(got or {}, ", "))
+		print("        want: " .. table.concat(want, ", "))
+	end
+end
+
+local function check_error(name, got, want_nil, err)
+	if got == want_nil and type(err) == "string" then
+		pass = pass + 1
+		print("  ok   " .. name .. " (" .. err .. ")")
+	else
+		fail = fail + 1
+		print("  FAIL " .. name .. " (expected an error, got a result)")
+	end
+end
+
+print("parser_test.lua")
+
+check("comma list", Parser.expand("project/{src,include,docs,tests}"), {
+	"project/src", "project/include", "project/docs", "project/tests",
+})
+
+check("no braces", Parser.expand("plain/path"), { "plain/path" })
+
+check("single-item brace is literal", Parser.expand("note-{v1}"), { "note-{v1}" })
+
+check_error("unbalanced brace", Parser.expand("project/{src,docs"), nil, "err")
+
+check_error("empty pattern", Parser.expand(""), nil, "err")
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/brace.yazi/tests/range_test.lua
+++ b/brace.yazi/tests/range_test.lua
@@ -1,0 +1,53 @@
+-- tests/range_test.lua
+-- Run with: cd tests && lua range_test.lua
+package.path = "../?.lua;./?.lua;" .. package.path
+local Parser = require("parser")
+
+local pass, fail = 0, 0
+
+local function eq_list(a, b)
+	if not a or #a ~= #b then
+		return false
+	end
+	for i = 1, #a do
+		if a[i] ~= b[i] then
+			return false
+		end
+	end
+	return true
+end
+
+local function check(name, got, want)
+	if eq_list(got, want) then
+		pass = pass + 1
+		print("  ok   " .. name)
+	else
+		fail = fail + 1
+		print("  FAIL " .. name)
+		print("        got:  " .. table.concat(got or {}, ", "))
+		print("        want: " .. table.concat(want, ", "))
+	end
+end
+
+print("range_test.lua")
+
+check("numeric ascending", Parser.expand("chapter{1..5}"), {
+	"chapter1", "chapter2", "chapter3", "chapter4", "chapter5",
+})
+
+check("numeric descending", Parser.expand("count{5..1}"), {
+	"count5", "count4", "count3", "count2", "count1",
+})
+
+check("numeric zero-padded", Parser.expand("img{01..03}"), {
+	"img01", "img02", "img03",
+})
+
+check("alpha uppercase", Parser.expand("{A..D}"), { "A", "B", "C", "D" })
+
+check("alpha lowercase", Parser.expand("{a..d}"), { "a", "b", "c", "d" })
+
+check("alpha descending", Parser.expand("{d..a}"), { "d", "c", "b", "a" })
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/brace.yazi/util.lua
+++ b/brace.yazi/util.lua
@@ -1,0 +1,34 @@
+-- util.lua
+-- Small stateless helper functions shared across brace.yazi modules.
+local Util = {}
+
+-- Remove leading/trailing whitespace.
+function Util.trim(s)
+	return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- Return true if `s` is nil, empty, or only whitespace.
+function Util.is_blank(s)
+	return s == nil or Util.trim(s) == ""
+end
+
+-- Deduplicate a list of strings while preserving first-seen order.
+function Util.dedup(list)
+	local seen = {}
+	local result = {}
+	for _, v in ipairs(list) do
+		if not seen[v] then
+			seen[v] = true
+			result[#result + 1] = v
+		end
+	end
+	return result
+end
+
+-- Sort a list of strings alphabetically, in place, and return it.
+function Util.sort(list)
+	table.sort(list)
+	return list
+end
+
+return Util


### PR DESCRIPTION
This plugin adds Bash-like brace expansion support for creating directories in Yazi.

Features:
- Comma lists: project/{src,include,docs}
- Nested braces: project/{src/{main,test},docs}
- Numeric ranges: chapter{1..5}, img{01..03}
- Alphabetic ranges: {A..D}, {a..d}
- Cartesian product: {ios,android}/{debug,release}
- Recursive mkdir using Yazi's filesystem API
- Preview with Enter/Esc confirmation

Pure Lua implementation, no shell calls, no external dependencies.