### PR TITLE
fix(term-cwd): missing slash for OSC7 on windows

### DIFF
--- a/term-cwd.yazi/main.lua
+++ b/term-cwd.yazi/main.lua
@@ -8,13 +8,10 @@ local function setup(_, opts)
     local writers = {
         -- Recommended for unix
         OSC7 = function(cwd)
-            -- Convert and percent-encode the path to a valid file URI for OSC 7.
+            -- Add starting slash on windows to separate the drive letter from hostname
             if target == "windows" then
-                cwd = "/" .. cwd:gsub("\\", "/")
+                cwd = "/" .. cwd
             end
-            cwd = cwd:gsub("([^%w%-%._~/])", function(char)
-                return string.format("%%%02X", char:byte())
-            end)
             io.write("\x1b]7;file://localhost" .. cwd .. "\x1b\\")
         end,
         -- Recommended for windows

--- a/term-cwd.yazi/main.lua
+++ b/term-cwd.yazi/main.lua
@@ -8,6 +8,13 @@ local function setup(_, opts)
     local writers = {
         -- Recommended for unix
         OSC7 = function(cwd)
+            -- Convert and percent-encode the path to a valid file URI for OSC 7.
+            if target == "windows" then
+                cwd = "/" .. cwd:gsub("\\", "/")
+            end
+            cwd = cwd:gsub("([^%w%-%._~/])", function(char)
+                return string.format("%%%02X", char:byte())
+            end)
             io.write("\x1b]7;file://localhost" .. cwd .. "\x1b\\")
         end,
         -- Recommended for windows


### PR DESCRIPTION
I'm trying this new plugin (#227) but it doesn't work on wezterm on windows since it needs OSC7, but it's passing the plain path and that doesn't work, it needs to be properly encoded. This also fixes on unix if the path had an illegal character but it's more noticeable on windows since every path contains illegal characters.