### PR TITLE
Change config to override behaviour

### DIFF
--- a/mime-ext.yazi/README.md
+++ b/mime-ext.yazi/README.md
@@ -33,18 +33,30 @@ group = "mime"
 You can also customize it in your `~/.config/yazi/init.lua` with:
 
 ```lua
-require("mime-ext.local"):setup {
-	-- Expand the existing filename database (lowercase), for example:
-	with_files = {
+local mimeExt = require("mime-ext.local")
+
+mimeExt:setup {
+    -- Override the existing filename database (lowercase):
+    files = {
+        makefile = "text/makefile",
+        -- ...
+    },
+	-- ... OR expand it instead:
+	files = ya.dict_merge(mimeExt.defaults.FILES, {
 		makefile = "text/makefile",
 		-- ...
-	},
+	}),
 
-	-- Expand the existing extension database (lowercase), for example:
-	with_exts = {
+    -- Override the existing extension database (lowercase):
+    exts = {
+        mk = "text/makefile",
+        -- ...
+    },
+	-- ... OR expand it instead:
+	exts = ya.dict_merge(mimeExt.defaults.EXTS, {
 		mk = "text/makefile",
 		-- ...
-	},
+	}),
 
 	-- If the MIME type is not in both filename and extension databases,
 	-- then fallback to Yazi's preset `mime.local` plugin, which uses `file(1)`

--- a/mime-ext.yazi/README.md
+++ b/mime-ext.yazi/README.md
@@ -36,27 +36,20 @@ You can also customize it in your `~/.config/yazi/init.lua` with:
 local mimeExt = require("mime-ext.local")
 
 mimeExt:setup {
-    -- Override the existing filename database (lowercase):
+    -- Expand the existing filename database (lowercase), for example:
     files = {
         makefile = "text/makefile",
         -- ...
     },
-	-- ... OR expand it instead:
-	files = ya.dict_merge(mimeExt.defaults.FILES, {
-		makefile = "text/makefile",
-		-- ...
-	}),
 
-    -- Override the existing extension database (lowercase):
+    -- Expand the existing extension database (lowercase), for example:
     exts = {
         mk = "text/makefile",
         -- ...
     },
-	-- ... OR expand it instead:
-	exts = ya.dict_merge(mimeExt.defaults.EXTS, {
-		mk = "text/makefile",
-		-- ...
-	}),
+
+    -- Disable defaults to only include the above
+    useDefaults = false,
 
 	-- If the MIME type is not in both filename and extension databases,
 	-- then fallback to Yazi's preset `mime.local` plugin, which uses `file(1)`

--- a/mime-ext.yazi/README.md
+++ b/mime-ext.yazi/README.md
@@ -37,13 +37,13 @@ local mimeExt = require("mime-ext.local")
 
 mimeExt:setup {
     -- Expand the existing filename database (lowercase), for example:
-    files = {
+    with_files = {
         makefile = "text/makefile",
         -- ...
     },
 
     -- Expand the existing extension database (lowercase), for example:
-    exts = {
+    with_exts = {
         mk = "text/makefile",
         -- ...
     },

--- a/mime-ext.yazi/local.lua
+++ b/mime-ext.yazi/local.lua
@@ -1087,8 +1087,8 @@ end
 
 function M:fetch(job)
 	local opts = options()
-	local merged_files = ya.dict_merge(FILES, opts.with_files or {})
-	local merged_exts = ya.dict_merge(EXTS, opts.with_exts or {})
+	local files = opts.with_files or FILES
+	local exts = opts.with_exts or EXTS
 
 	local updates, unknown, state = {}, {}, {}
 	for i, file in ipairs(job.files) do
@@ -1101,8 +1101,8 @@ function M:fetch(job)
 		if file.cha.len == 0 then
 			mime = "inode/empty"
 		else
-			mime = merged_files[(file.url.name or ""):lower()]
-			mime = mime or merged_exts[(file.url.ext or ""):lower()]
+			mime = files[(file.url.name or ""):lower()]
+			mime = mime or exts[(file.url.ext or ""):lower()]
 		end
 
 		if mime then

--- a/mime-ext.yazi/local.lua
+++ b/mime-ext.yazi/local.lua
@@ -1077,6 +1077,11 @@ local options = ya.sync(
 
 local M = {}
 
+M.defaults = {
+	FILES = FILES,
+	EXTS = EXTS,
+}
+
 function M:setup(opts)
 	opts = opts or {}
 

--- a/mime-ext.yazi/local.lua
+++ b/mime-ext.yazi/local.lua
@@ -1068,8 +1068,8 @@ local EXTS = {
 local options = ya.sync(
 	function(st)
 		return {
-			with_files = st.with_files,
-			with_exts = st.with_exts,
+			files = st.files,
+			exts = st.exts,
 			fallback_file1 = st.fallback_file1,
 		}
 	end
@@ -1080,15 +1080,15 @@ local M = {}
 function M:setup(opts)
 	opts = opts or {}
 
-	self.with_files = opts.with_files
-	self.with_exts = opts.with_exts
+	self.files = opts.files
+	self.exts = opts.exts
 	self.fallback_file1 = opts.fallback_file1
 end
 
 function M:fetch(job)
 	local opts = options()
-	local files = opts.with_files or FILES
-	local exts = opts.with_exts or EXTS
+	local files = opts.files or FILES
+	local exts = opts.exts or EXTS
 
 	local updates, unknown, state = {}, {}, {}
 	for i, file in ipairs(job.files) do

--- a/mime-ext.yazi/local.lua
+++ b/mime-ext.yazi/local.lua
@@ -1068,8 +1068,8 @@ local EXTS = {
 local options = ya.sync(
 	function(st)
 		return {
-			files = st.files or {},
-			exts = st.exts or {},
+			with_files = st.with_files or {},
+			with_exts = st.with_exts or {},
 			useDefaults = st.useDefaults,
 			fallback_file1 = st.fallback_file1,
 		}
@@ -1086,8 +1086,8 @@ M.defaults = {
 function M:setup(opts)
 	opts = opts or {}
 
-	self.files = opts.files
-	self.exts = opts.exts
+	self.with_files = opts.with_files
+	self.with_exts = opts.with_exts
 	self.useDefaults = opts.useDefaults
 	self.fallback_file1 = opts.fallback_file1
 end
@@ -1096,11 +1096,11 @@ function M:fetch(job)
 	local opts = options()
 	local files, exts
 	if opts.useDefaults ~= false then -- If nil, also take this path
-		files = ya.dict_merge(FILES, opts.files)
-		exts = ya.dict_merge(EXTS, opts.exts)
+		files = ya.dict_merge(FILES, opts.with_files)
+		exts = ya.dict_merge(EXTS, opts.with_exts)
 	else
-		files = opts.files
-		exts = opts.exts
+		files = opts.with_files
+		exts = opts.with_exts
 	end
 
 	local updates, unknown, state = {}, {}, {}

--- a/mime-ext.yazi/local.lua
+++ b/mime-ext.yazi/local.lua
@@ -1068,8 +1068,9 @@ local EXTS = {
 local options = ya.sync(
 	function(st)
 		return {
-			files = st.files,
-			exts = st.exts,
+			files = st.files or {},
+			exts = st.exts or {},
+			useDefaults = st.useDefaults,
 			fallback_file1 = st.fallback_file1,
 		}
 	end
@@ -1087,13 +1088,20 @@ function M:setup(opts)
 
 	self.files = opts.files
 	self.exts = opts.exts
+	self.useDefaults = opts.useDefaults
 	self.fallback_file1 = opts.fallback_file1
 end
 
 function M:fetch(job)
 	local opts = options()
-	local files = opts.files or FILES
-	local exts = opts.exts or EXTS
+	local files, exts
+	if opts.useDefaults ~= false then -- If nil, also take this path
+		files = ya.dict_merge(FILES, opts.files)
+		exts = ya.dict_merge(EXTS, opts.exts)
+	else
+		files = opts.files
+		exts = opts.exts
+	end
 
 	local updates, unknown, state = {}, {}, {}
 	for i, file in ipairs(job.files) do


### PR DESCRIPTION
## What
Increase configurability by allowing fully overriding the pre-packages type rules

## Why
I personally wanted to use this plugin to make `.lua` files explicitly point to `text/lua` since I [had one](https://github.com/TCAGM-Dev/dotfiles/blob/main/stow/.config/nvim/lua/plugins/galaxyline.lua) that was recognised as `application/octet-stream` and not being opened in my text editor by default, but this wasn't possible (while keeping `file(1)` for the rest) just because this plugin's settings only allowed appending to the defaults

## Considerations
This *is* a breaking change, as not only has the behaviour of the settings changed, it's exact keys have as well. However this seems like the better option as otherwise we'd confusingly have *two keys* for the "same thing".
I have also exported the default types so these can be used to replicate the previous behaviour by the user, as outlined in `README.md`.